### PR TITLE
feat!: add TypeQueryNode to schema (fix #42 )

### DIFF
--- a/Xantham.slnx
+++ b/Xantham.slnx
@@ -5,7 +5,6 @@
     <Project Path="Build.fsproj" />
   </Folder>
   <Folder Name="/ai/">
-    <File Path="CLAUDE.md" />
     <File Path="AGENTS.md" />
   </Folder>
   <Folder Name="/ai/rules/">

--- a/src/Xantham.Common/Common.Types.fs
+++ b/src/Xantham.Common/Common.Types.fs
@@ -2,10 +2,10 @@
 #if FABLE_COMPILER
 open Thoth.Json
 open Fable.Core
-[<Erase>]
 /// <summary>
 /// A unique identifier for a type.
 /// </summary>
+[<Erase>]
 type TypeKey = TypeKey of int
 module TypeKey =
     let inline createWith (i: int) = TypeKey i
@@ -631,6 +631,20 @@ type TsTypePredicate = {
     Type: TypeKey
     IsAssertion: bool
 }
+
+/// <summary>
+/// Represents a type query like `typeof Foo` or `typeof Foo.bar`.
+/// The type query is resolved to the type of the referenced entity.
+/// </summary>
+/// <remarks>
+/// The name is provided so that enum like type query unions can have
+/// names inferred from the query appropriately.<br/>
+/// This is the cheapest schema representation.
+/// </remarks>
+type TsTypeQuery = {
+    FullyQualifiedName: string list
+    Type: TypeKey
+}
 /// <summary>
 /// Represents a <c>namespace</c> or <c>module</c> declaration and the collected types within it.
 /// 
@@ -641,7 +655,7 @@ type TsTypePredicate = {
 /// declare namespace MyLib { const version: string }
 /// </code>
 /// </example>
-type TsModule = {
+and TsModule = {
     Source: string option
     FullyQualifiedName: string list
     Name: string
@@ -672,6 +686,7 @@ and [<RequireQualifiedAccess>] TsType =
     | TemplateLiteral of TsTemplateLiteralType
     | Optional of TsTypeReference
     | Substitution of TsSubstitutionType
+    | TypeQuery of TsTypeQuery
 
     /// Discriminated union of all high-level TypeScript type shapes the reader can produce.
     /// Each case mirrors a concrete TS type or declaration form (see individual types above).
@@ -742,6 +757,7 @@ and [<RequireQualifiedAccess>] TsAstNode =
     | Intersection of TsTypeIntersection
     | Optional of TsTypeReference
     | Module of TsModule
+    | TypeQuery of TsTypeQuery
     member this.IsExport =
         match this with
         | Class _
@@ -768,6 +784,7 @@ and [<RequireQualifiedAccess>] TsAstNode =
         | Conditional _
         | Union _
         | Intersection _
+        | TypeQuery _
         | Optional _ -> false
     member this.IsType =
         match this with
@@ -795,6 +812,7 @@ and [<RequireQualifiedAccess>] TsAstNode =
         | Conditional _
         | Union _
         | Intersection _
+        | TypeQuery _
         | Optional _ -> true
     member this.ToType() =
         match this with
@@ -823,6 +841,7 @@ and [<RequireQualifiedAccess>] TsAstNode =
         | Union v -> TsType.Union v |> ValueSome
         | Intersection v -> TsType.Intersection v |> ValueSome
         | Optional v -> TsType.Optional v |> ValueSome
+        | TypeQuery v -> TsType.TypeQuery v |> ValueSome
     member this.ToExportDeclaration() =
         match this with
         | Class v -> TsExportDeclaration.Class v |> ValueSome
@@ -849,9 +868,14 @@ and [<RequireQualifiedAccess>] TsAstNode =
         | Conditional _
         | Union _
         | Intersection _
+        | TypeQuery _
         | Optional _ -> ValueNone
     member this.ToTypeExportDeclaration() =
         this.ToType(), this.ToExportDeclaration()
+        
+[<AutoOpen>]
+module private Utils =
+    let inline mock<'T> = Unchecked.defaultof<'T>
 
 module TsOverloadableConstruct =
     let encode (encoder: Encoder<'T>) (value: TsOverloadableConstruct<'T>) =
@@ -874,57 +898,57 @@ module TsComment =
         Encode.object [
             match value with
             | TsComment.Summary l ->
-                "Summary",
+                nameof TsComment.Summary,
                 l |> List.map Encode.string |> Encode.list
             | TsComment.Returns s ->
-                "Returns",
+                nameof TsComment.Returns,
                 Encode.string s
             | TsComment.Param(name, content) ->
-                "Param", Encode.string name
+                nameof TsComment.Param, Encode.string name
                 "Content", content |> Encode.option Encode.string
             | TsComment.Deprecated stringOption ->
-                "Deprecated", stringOption |> Encode.option Encode.string
+                nameof TsComment.Deprecated, stringOption |> Encode.option Encode.string
             | TsComment.Remarks s ->
-                "Remarks", Encode.string s
+                nameof TsComment.Remarks, Encode.string s
             | TsComment.DefaultValue s ->
-                "DefaultValue", Encode.string s
+                nameof TsComment.DefaultValue, Encode.string s
             | TsComment.Example s ->
-                "Example", Encode.string s
+                nameof TsComment.Example, Encode.string s
             | TsComment.TypeParam(typeName, content) ->
-                "TypeParam", Encode.string typeName
+                nameof TsComment.TypeParam, Encode.string typeName
                 "Content", content |> Encode.option Encode.string
             | TsComment.Throws s ->
-                "Throws", Encode.string s
+                nameof TsComment.Throws, Encode.string s
         ]
     let decode: Decoder<TsComment> = Decode.oneOf [
         Decode.object <| fun get ->
-            get.Required.Field "Summary" (Decode.list Decode.string)
+            get.Required.Field (nameof TsComment.Summary) (Decode.list Decode.string)
             |> TsComment.Summary
         Decode.object <| fun get ->
-            get.Required.Field "Returns" Decode.string
+            get.Required.Field (nameof TsComment.Returns) Decode.string
             |> TsComment.Returns
         Decode.object <| fun get ->
-            let param = get.Required.Field "Param" Decode.string
+            let param = get.Required.Field (nameof TsComment.Param) Decode.string
             let content = get.Required.Field "Content" (Decode.option Decode.string)
             TsComment.Param(param, content)
         Decode.object <| fun get ->
-            get.Required.Field "Deprecated" (Decode.option Decode.string)
+            get.Required.Field (nameof TsComment.Deprecated) (Decode.option Decode.string)
             |> TsComment.Deprecated 
         Decode.object <| fun get ->
-            get.Required.Field "Remarks" Decode.string
+            get.Required.Field (nameof TsComment.Remarks) Decode.string
             |> TsComment.Remarks
         Decode.object <| fun get ->
-            get.Required.Field "DefaultValue" Decode.string
+            get.Required.Field (nameof TsComment.DefaultValue) Decode.string
             |> TsComment.DefaultValue
         Decode.object <| fun get ->
-            get.Required.Field "Example" Decode.string
+            get.Required.Field (nameof TsComment.Example) Decode.string
             |> TsComment.Example
         Decode.object <| fun get ->
-            let typeName = get.Required.Field "TypeParam" Decode.string
+            let typeName = get.Required.Field (nameof TsComment.TypeParam) Decode.string
             let content = get.Required.Field "Content" (Decode.option Decode.string)
             TsComment.TypeParam(typeName, content)
         Decode.object <| fun get ->
-            get.Required.Field "Throws" Decode.string
+            get.Required.Field (nameof TsComment.Throws) Decode.string
             |> TsComment.Throws
     ]
 module TsLiteral =
@@ -1508,6 +1532,18 @@ module TsTypePredicate =
             IsAssertion = get.Required.Field "IsAssertion" Decode.bool
         }
 
+module TsTypeQuery =
+    let encode (value: TsTypeQuery) =
+        Encode.object [
+            nameof value.FullyQualifiedName, value.FullyQualifiedName |> List.map Encode.string |> Encode.list
+            nameof value.Type, TypeKey.encode value.Type
+        ]
+    let decode: Decoder<TsTypeQuery> =
+        Decode.object <| fun get -> {
+            FullyQualifiedName = get.Required.Field (nameof mock<TsTypeQuery>.FullyQualifiedName) (Decode.list Decode.string)
+            Type = get.Required.Field (nameof mock<TsTypeQuery>.Type) TypeKey.decode
+        }
+
 module TypeKindPrimitive =
     let encode (value: TypeKindPrimitive) =
         match value with
@@ -1567,6 +1603,7 @@ module TsType =
             | TsType.TemplateLiteral tl -> "TemplateLiteral", TsTemplateLiteralType.encode tl
             | TsType.Optional tr -> "Optional", TsTypeReference.encode tr
             | TsType.Substitution s -> "Substitution", TsSubstitutionType.encode s
+            | TsType.TypeQuery tsTypeQuery -> nameof TsType.TypeQuery, TsTypeQuery.encode tsTypeQuery
         ]
     let rec decode: Decoder<TsType> =
         fun path value ->
@@ -1593,6 +1630,7 @@ module TsType =
                 Decode.object (fun get -> get.Required.Field "TemplateLiteral" TsTemplateLiteralType.decode |> TsType.TemplateLiteral)
                 Decode.object (fun get -> get.Required.Field "Optional" TsTypeReference.decode |> TsType.Optional)
                 Decode.object (fun get -> get.Required.Field "Substitution" TsSubstitutionType.decode |> TsType.Substitution)
+                Decode.object (fun get -> get.Required.Field (nameof TsType.TypeQuery) TsTypeQuery.decode |> TsType.TypeQuery)
             ] path value
 
 module TsModule =

--- a/src/Xantham.Decoder/Runtime.fs
+++ b/src/Xantham.Decoder/Runtime.fs
@@ -160,6 +160,8 @@ type XanthamTree(settings: Settings) =
             | TsType.Interface _ -> CodeKey.ExportCodeKey.Interface  key |> CodeKey.CodeKey.Export
             | TsType.Class _ -> CodeKey.ExportCodeKey.Class  key |> CodeKey.CodeKey.Export
             | TsType.Enum _ -> CodeKey.ExportCodeKey.Enum  key |> CodeKey.CodeKey.Export
+            | TsType.TypeQuery _ -> CodeKey.TypeCodeKey.TypeQuery key |> CodeKey.CodeKey.Type
+
     /// <summary>
     /// Build a dependency graph over the decoded type/export maps.
     /// Conditional <c>Check</c>/<c>Extends</c> branches are excluded from the edges.

--- a/src/Xantham.Decoder/Types/Arena.Interner.fs
+++ b/src/Xantham.Decoder/Types/Arena.Interner.fs
@@ -54,7 +54,6 @@ open System.Collections.Generic
 open FSharp.Control
 open Xantham
 open Xantham.Decoder
-open Xantham.Decoder.Types
 open Xantham.Decoder.Types.Graph
 
 /// <summary>
@@ -112,6 +111,7 @@ type [<RequireQualifiedAccess>] ResolvedType =
     | TemplateLiteral of TemplateLiteral
     | Optional of TypeReference
     | Substitution of SubstitutionType
+    | TypeQuery of TypeQuery
 
 /// <summary>
 /// The resolved (lazy-graph) form of a top-level TypeScript export declaration.
@@ -158,6 +158,11 @@ and [<ReferenceEquality>] Module = {
     IsNamespace: bool
     IsRecursive: bool
     Exports: ResolvedExport list
+}
+
+and [<ReferenceEquality>] TypeQuery = {
+    FullyQualifiedName: QualifiedNamePart list
+    Type: LazyResolvedType
 }
 
 and [<ReferenceEquality>] Index = {
@@ -729,6 +734,10 @@ module ArenaInterner =
             | TsType.Substitution tsSubstitutionType -> ResolvedType.Substitution {
                     Base = lazyResolve tsSubstitutionType.Base
                     Constraint = lazyResolve tsSubstitutionType.Constraint
+                }
+            | TsType.TypeQuery tsTypeQuery -> ResolvedType.TypeQuery {
+                    FullyQualifiedName = tsTypeQuery.FullyQualifiedName |> List.map QualifiedNamePart.create
+                    Type = lazyResolve tsTypeQuery.Type
                 }
         and buildFromTypeParameter (key: TypeKey, _) =
             lazy

--- a/src/Xantham.Decoder/Types/CodedTypeKey.fs
+++ b/src/Xantham.Decoder/Types/CodedTypeKey.fs
@@ -51,6 +51,8 @@ type TypeCodeKey =
     | Optional of optional: TypeKey
     /// A substitution type used in conditional/distributive type checking.
     | Substitution of substitution: TypeKey
+    ///<summary>A type query (<c>typeof T</c>).</summary>
+    | TypeQuery of typeQuery: TypeKey
 
 /// <summary>
 /// A <c>TypeKey</c> tagged with the <c>TsExportDeclaration</c> case it identifies.

--- a/src/Xantham.Decoder/Types/Graph.fs
+++ b/src/Xantham.Decoder/Types/Graph.fs
@@ -227,6 +227,12 @@ module Graph =
                             TypeKey = kv.Key
                             Dependencies = Set [ tsSubstitutionType.Base; tsSubstitutionType.Constraint ]
                         }
+                    | TsType.TypeQuery tsTypeQuery ->
+                        {
+                            TypeKey = kv.Key
+                            Dependencies = Set [ tsTypeQuery.Type ]
+                        }
+
                 matcher kv.Value
         }
         |> TaskSeq.iter (fun node ->

--- a/src/Xantham.Decoder/Utils.fs
+++ b/src/Xantham.Decoder/Utils.fs
@@ -128,6 +128,7 @@ let rec getKeys typ =
     | TsType.TemplateLiteral tsTemplateLiteralType -> tsTemplateLiteralType.Types |> List.toArray
     | TsType.Optional tsTypeReference -> getKeys (TsType.TypeReference tsTypeReference)
     | TsType.Substitution tsSubstitutionType -> [| tsSubstitutionType.Base; tsSubstitutionType.Constraint |]
+    | TsType.TypeQuery tsTypeQuery -> [| tsTypeQuery.Type |]
 
 /// <summary>
 /// Recursively collects all keys from a <c>TsExportDeclaration</c>.
@@ -332,6 +333,8 @@ let private compressWithMap (types: Map<TypeKey, TsType>) (compressions: Diction
                 Base = swap tsSubstitutionType.Base
                 Constraint = swap tsSubstitutionType.Constraint
             }
+        | TsType.TypeQuery tsTypeQuery ->
+            TsType.TypeQuery { tsTypeQuery with Type = swap tsTypeQuery.Type }
 
     types
     |> Map.toArray

--- a/src/Xantham.Fable/Read.fs
+++ b/src/Xantham.Fable/Read.fs
@@ -1,16 +1,10 @@
 ﻿[<AutoOpen>]
 module Xantham.Fable.Main
 
-open System.Collections.Generic
-open System.Text.RegularExpressions
 open Fable.Core.DynamicExtensions
-open Fable.Core.JsInterop
-open Fable.Core
 open Node
 open Thoth.Json
-open TypeScript
 open Xantham
-open System.Collections
 open Xantham.Fable.Reading
 open Xantham.Fable.Reading.Entry
 open Xantham.Fable.Types
@@ -85,6 +79,8 @@ module Internal =
             | TsType.TypeReference { ResolvedType = Some key }
             | TsType.TypeReference { Type = key } when key = typKey -> Log.healthCheckError typKey tsType tsType
             | _ -> ()
+        | TsType.TypeQuery ({ Type = key } as typeQuery) ->
+            if typKey = key then Log.healthCheckError typKey typeQuery typeQuery
 
     let private unknownKey = TypeKindPrimitive.Unknown.TypeKey
     

--- a/src/Xantham.Fable/Reading/Dispatch/ModulesAndExports.fs
+++ b/src/Xantham.Fable/Reading/Dispatch/ModulesAndExports.fs
@@ -9,10 +9,10 @@ open Xantham.Fable.Types.Signal
 
 let dispatch (ctx: TypeScriptReader) (xanTag: XanthamTag) (tag: ModulesAndExports) =
     match tag with
-    | ModulesAndExports.ImportDeclaration mportDeclaration -> ()
-    | ModulesAndExports.ImportClause mportClause -> ()
-    | ModulesAndExports.NamespaceImport namespaceImport -> ()
-    | ModulesAndExports.NamedImports namedImports -> ()
+    | ModulesAndExports.ImportDeclaration _ -> ()
+    | ModulesAndExports.ImportClause _ -> ()
+    | ModulesAndExports.NamespaceImport _ -> ()
+    | ModulesAndExports.NamedImports _ -> ()
     | ModulesAndExports.ImportSpecifier mportSpecifier ->
         match
             ctx.checker.getSymbolAtLocation(mportSpecifier.name)
@@ -69,9 +69,9 @@ let dispatch (ctx: TypeScriptReader) (xanTag: XanthamTag) (tag: ModulesAndExport
                 xanTag.ExportBuilder
                 |> Signal.fulfillWith (fun () -> decl.ExportBuilder.Value)
         | None -> Log.error "failed to get symbol"
-    | ModulesAndExports.AssertClause assertClause -> ()
-    | ModulesAndExports.ExportAssignment exportAssignment -> ()
-    | ModulesAndExports.ExportDeclaration exportDeclaration -> ()
+    | ModulesAndExports.AssertClause _ -> ()
+    | ModulesAndExports.ExportAssignment _ -> ()
+    | ModulesAndExports.ExportDeclaration _ -> ()
     | ModulesAndExports.ExportSpecifier exportSpecifier ->
         let source =
             xanTag
@@ -108,5 +108,5 @@ let dispatch (ctx: TypeScriptReader) (xanTag: XanthamTag) (tag: ModulesAndExport
                 xanTag.ExportBuilder
                 |> Signal.fulfillWith (fun () -> decl.ExportBuilder.Value)
         | None -> Log.error "failed to get symbol"
-    | ModulesAndExports.NamedExports namedExports -> ()
-    | ModulesAndExports.NamespaceExport namespaceExportDeclaration -> ()
+    | ModulesAndExports.NamedExports _ -> ()
+    | ModulesAndExports.NamespaceExport _ -> ()

--- a/src/Xantham.Fable/Reading/Dispatch/TypeNode.fs
+++ b/src/Xantham.Fable/Reading/Dispatch/TypeNode.fs
@@ -75,7 +75,9 @@ let dispatch (ctx: TypeScriptReader) (xanTag: XanthamTag) (tag: TypeNode) =
             { STypeUnionBuilder.Types = Array.map getTypeSignalFromNode types }
             |> SType.Union
             |> setAstSignal
-            setTypeKeyFromNode unionTypeNode
+            ctx.signalCache[xanTag.IdentityKey].Key
+            |> setTypeKeyForTag xanTag
+            // setTypeKeyFromNode unionTypeNode
             // TypeStore.Key is generated (see Prelude.usesGeneratedKey) but TypeSignal is set to
             // the semantic union's natural TypeKey via setTypeKeyFromNode. Parents embed that
             // natural TypeKey in their type fields. Ensure the semantic union type-level entry
@@ -256,7 +258,32 @@ let dispatch (ctx: TypeScriptReader) (xanTag: XanthamTag) (tag: TypeNode) =
     | TypeNode.TypeQuery typeQueryNode ->
         XanthamTag.debugLocationAndForget "TypeNode.dispatch | TypeQuery" xanTag
         // typeof X — resolve to the static type of X
-        routeViaChecker typeQueryNode
+        let rec foldEntityName (acc: ResizeArray<string>) (entityName: Ts.EntityName) =
+            match entityName with
+            | Patterns.Node.EntityNamePatterns.Identifier identifier -> acc.Add(identifier.text)
+            | Patterns.Node.EntityNamePatterns.QualifiedName qualifiedName ->
+                foldEntityName acc qualifiedName.left
+                acc.Add(qualifiedName.right.text)
+        let entityName =
+            let result = ResizeArray<string>()
+            foldEntityName result typeQueryNode.exprName
+            result.AsArray
+        let resolvedType = ctx.checker.getTypeFromTypeNode typeQueryNode
+        let innerTag =
+            ctx.CreateXanthamTag resolvedType |> fst
+            |> TagState.apply (function
+                | true -> XanthamTag.chainDebug xanTag >> pushToStack ctx
+                | false -> XanthamTag.chainDebug xanTag >> ignore)
+            |> _.Value
+        {
+            STypeQueryBuilder.FullyQualifiedName = entityName
+            Type = innerTag.TypeSignal
+        }
+        |> SType.TypeQuery
+        |> setAstSignal
+        // Type query uses a generated type signal
+        ctx.signalCache[xanTag.IdentityKey].Key
+        |> setTypeKeyForTag xanTag
     | TypeNode.TypeOperator typeOperatorNode ->
         XanthamTag.debugLocationAndForget "TypeNode.dispatch | TypeOperator" xanTag
         // keyof T → union of property keys; unique symbol → UniqueESSymbol; readonly → inner type

--- a/src/Xantham.Fable/Reading/Prelude.fs
+++ b/src/Xantham.Fable/Reading/Prelude.fs
@@ -76,6 +76,8 @@ module TypeStore =
         // semantic type produced by the checker.
         | XanTagKind.TypeNode (TypeNode.UnionType _)
         | XanTagKind.TypeNode (TypeNode.IntersectionType _) -> true
+        // TypeNode.TypeQuery: acts as a wrapper that captures the name used in the resolution
+        | XanTagKind.TypeNode (TypeNode.TypeQuery _) -> true
         // TypeNode.TypePredicate: getTypeFromTypeNode on a TypePredicate node returns the
         // boolean type, so all predicates would share the boolean TypeKey. Generated key
         // gives each predicate node its own unique TypeStore entry.

--- a/src/Xantham.Fable/Types/ReactiveBuilders.fs
+++ b/src/Xantham.Fable/Types/ReactiveBuilders.fs
@@ -544,6 +544,17 @@ type SPredicateBuilder = {
           Type = this.Type.Value
           IsAssertion = this.IsAssertion }
 
+/// <summary>
+/// Signal-based equivalent of <c>TsTypeQuery</c>, builds to <see cref="T:Xantham.TsTypeQuery"/>.
+/// </summary>
+type STypeQueryBuilder = {
+    FullyQualifiedName: string array
+    Type: TypeSignal
+} with
+    member this.Build() : TsTypeQuery =
+        { FullyQualifiedName = Array.toList this.FullyQualifiedName
+          Type = this.Type.Value }
+
 /// Signal-based equivalent of <c>TsModuleBuilder</c>, builds to <see cref="T:Xantham.TsModule"/>.
 type SModuleBuilder = {
     Source: Signal<ModuleName>
@@ -588,6 +599,7 @@ and [<RequireQualifiedAccess>] SType =
     | Intersection of STypeIntersectionBuilder
     | Optional of STypeReferenceBuilder
     | TemplateLiteral of STemplateLiteralTypeBuilder
+    | TypeQuery of STypeQueryBuilder
     member this.Build() : TsType =
         match this with
         | GlobalThis -> TsType.GlobalThis
@@ -611,6 +623,7 @@ and [<RequireQualifiedAccess>] SType =
         | Intersection sTypeIntersectionBuilder -> sTypeIntersectionBuilder.Build() |> TsType.Intersection
         | Optional sTypeReferenceBuilder -> sTypeReferenceBuilder.Build() |> TsType.Optional
         | TemplateLiteral sTemplateLiteralTypeBuilder -> sTemplateLiteralTypeBuilder.Build() |> TsType.TemplateLiteral
+        | TypeQuery sTypeQueryBuilder -> sTypeQueryBuilder.Build() |> TsType.TypeQuery
 
 and [<RequireQualifiedAccess>] STsExportDeclaration =
     | Interface of SInterfaceBuilder

--- a/src/Xantham.Fable/Types/Reader.Extensions.fs
+++ b/src/Xantham.Fable/Types/Reader.Extensions.fs
@@ -2,9 +2,7 @@
 module Xantham.Fable.Types.AutoOpenReaderExtensions
 
 open TypeScript
-open Xantham
 open Xantham.Fable
-open Xantham.Fable.Types.Signal
 
 type TypeScriptReader with
     member this.CreateXanthamTag(node: Ts.Node) =

--- a/src/Xantham.Fable/Types/Reader.fs
+++ b/src/Xantham.Fable/Types/Reader.fs
@@ -5,7 +5,6 @@ open System.Collections.Generic
 open Fable.Core.JsInterop
 open TypeScript
 open Xantham.Fable
-open Xantham
 open Xantham.Fable.Types
 open Xantham.Fable.Types.Tracer
 

--- a/src/Xantham.Generator/Generator/Render.Transient.fs
+++ b/src/Xantham.Generator/Generator/Render.Transient.fs
@@ -51,6 +51,32 @@ module Union =
                 Value = tsLiteral
                 Documentation = []
             }
+        | ResolvedTypeLiteralLike.TypeQuery typeQuery ->
+            let value =
+                match typeQuery.Type.Value with
+                | ResolvedType.Literal tsLiteral -> tsLiteral
+                | _ -> failwith "Cannot render union literal case for non literal type"
+            let name =
+                typeQuery.FullyQualifiedName
+                |> List.last
+                |> (_.Value >> Name.Pascal.create)
+            let path =
+                name
+                |> Case.unboxMeasure
+                |> TransientMemberPath.AnchoredAndMoored
+                |> Path.create
+            {
+                Metadata = {
+                    Path = path
+                    Original = path
+                    Source = ValueNone
+                    FullyQualifiedName = ValueSome typeQuery.FullyQualifiedName
+                }
+                Name = ValueSome name
+                Value = value
+                Documentation = []
+            }
+
     let private renderUnionLiterals (ctx: GeneratorContext) (scopeStore: RenderScopeStore) (literals: ResolvedTypeLiteralLike list) =
         {
             Metadata = { Path = Path.create TransientTypePath.Anchored
@@ -87,6 +113,26 @@ module Union =
                 Value = value
                 Documentation = []
             }
+        | ResolvedTypeLiteralLike.TypeQuery { FullyQualifiedName = fqn; Type = Resolve (ResolvedType.Literal (TsLiteral.Int value))  } ->
+            let name =
+                fqn
+                |> List.last
+                |> _.Value
+                |> Name.Pascal.create
+            let path =
+                name
+                |> Case.unboxMeasure
+                |> TransientMemberPath.AnchoredAndMoored
+                |> Path.create
+            {
+                Metadata =
+                    RenderMetadata.createWithPath path
+                    |> RenderMetadata.withFullyQualifiedName fqn
+                Name = ValueSome name
+                Value = value
+                Documentation = []
+            }
+        | ResolvedTypeLiteralLike.TypeQuery _
         | ResolvedTypeLiteralLike.EnumCase _ 
         | ResolvedTypeLiteralLike.Literal _ -> failwith "Cannot render enum literal case for non int literal. This should be guarded against"
 
@@ -107,6 +153,7 @@ module Union =
             literals
             |> List.forall (function
                 | ResolvedTypeLiteralLike.EnumCase { Value = TsLiteral.Int _ }
+                | ResolvedTypeLiteralLike.TypeQuery { Type = Resolve (ResolvedType.Literal (TsLiteral.Int _)) }
                 | ResolvedTypeLiteralLike.Literal (TsLiteral.Int _) -> true
                 | _ -> false
                 )

--- a/src/Xantham.Generator/Generator/Render.TypeAlias.fs
+++ b/src/Xantham.Generator/Generator/Render.TypeAlias.fs
@@ -23,229 +23,232 @@ module TypeAlias =
         let metadata =
             (Path.create path, typ)
             ||> RenderMetadata.createWithPathFromExport
-        match innerType.Value with
-        | ResolvedType.Interface _
-        | ResolvedType.Class _
-        | ResolvedType.Primitive _
-        | ResolvedType.IndexedAccess _
-        | ResolvedType.Index _
-        | ResolvedType.Tuple _
-        | ResolvedType.TypeParameter _
-        | ResolvedType.TypeReference _
-        | ResolvedType.Predicate _
-        | ResolvedType.Substitution _
-        | ResolvedType.Optional _
-        | ResolvedType.GlobalThis
-        | ResolvedType.Conditional _
-        | ResolvedType.Enum _
-        | ResolvedType.Array _ ->
-            let oldRef = ctx.PreludeGetTypeRef ctx scopeStore innerType
-            let innerRef =
-                match ctx.PreludeRenders.TryGetValue(innerType.Value) with
-                | true, value -> ValueSome value
-                | false, _ -> ValueNone
-                |> ValueOption.map (fun newRef ->
-                    match ctx.TypeAliasRemap.TryGetValue(innerType.Value) with
-                    | true, value ->
-                        TypeRefRender.replace value newRef.TypeRef oldRef
-                    | _ -> newRef.TypeRef
-                    )
-                |> ValueOption.defaultValue oldRef
-                
-            {
-                TypeAliasRenderRef.Documentation = documentation
-                Metadata = metadata
-                Name = name
-                TypeParameters = typeParameters
-                Type = innerRef
-            }
-            |> TypeAliasRender.Alias
-        | ResolvedType.Intersection _ 
-        | ResolvedType.TypeLiteral _ ->
-            let members, functions =
-                Member.collectAllRecursively innerType.Value
-                |> Member.partitionRender ctx scopeStore
-            // if members |> List.isEmpty && functions |> List.forall (_.Name >> Name.Case.valueOrSource >> (=) "Invoke") then
-                // ()
-            // else
-            {
-                TypeLikeRender.Metadata = metadata
-                Name = name
-                TypeParameters = typeParameters
-                Members = members 
-                Functions = functions 
-                Inheritance = []
-                Constructors = []
-                Documentation = documentation
-            }
-            |> TypeAliasRender.TypeDefn
-        | ResolvedType.Union _ ->
-            let typeRefRender =
+        let rec matchImpl = function
+            | ResolvedType.TypeQuery { Type = Resolve typ } ->
+                matchImpl typ
+            | ResolvedType.Interface _
+            | ResolvedType.Class _
+            | ResolvedType.Primitive _
+            | ResolvedType.IndexedAccess _
+            | ResolvedType.Index _
+            | ResolvedType.Tuple _
+            | ResolvedType.TypeParameter _
+            | ResolvedType.TypeReference _
+            | ResolvedType.Predicate _
+            | ResolvedType.Substitution _
+            | ResolvedType.Optional _
+            | ResolvedType.GlobalThis
+            | ResolvedType.Conditional _
+            | ResolvedType.Enum _
+            | ResolvedType.Array _ ->
+                let oldRef = ctx.PreludeGetTypeRef ctx scopeStore innerType
+                let innerRef =
+                    match ctx.PreludeRenders.TryGetValue(innerType.Value) with
+                    | true, value -> ValueSome value
+                    | false, _ -> ValueNone
+                    |> ValueOption.map (fun newRef ->
+                        match ctx.TypeAliasRemap.TryGetValue(innerType.Value) with
+                        | true, value ->
+                            TypeRefRender.replace value newRef.TypeRef oldRef
+                        | _ -> newRef.TypeRef
+                        )
+                    |> ValueOption.defaultValue oldRef
+                    
                 {
                     TypeAliasRenderRef.Documentation = documentation
                     Metadata = metadata
                     Name = name
                     TypeParameters = typeParameters
-                    Type = ctx.PreludeGetTypeRef ctx scopeStore innerType
+                    Type = innerRef
                 }
                 |> TypeAliasRender.Alias
-            match ResolvedTypeCategories.create innerType.Value with
-            // no literals, and no 'others' that require a transient type
-            | { LiteralLike = literals; Others = []; Nullable = nullable; Primitives = []; EnumLike = [] } ->
-                match Union.renderLiterals ctx scopeStore literals with
-                | TypeRender.EnumUnion enumRender ->
+            | ResolvedType.Intersection _ 
+            | ResolvedType.TypeLiteral _ ->
+                let members, functions =
+                    Member.collectAllRecursively innerType.Value
+                    |> Member.partitionRender ctx scopeStore
+                // if members |> List.isEmpty && functions |> List.forall (_.Name >> Name.Case.valueOrSource >> (=) "Invoke") then
+                    // ()
+                // else
+                {
+                    TypeLikeRender.Metadata = metadata
+                    Name = name
+                    TypeParameters = typeParameters
+                    Members = members 
+                    Functions = functions 
+                    Inheritance = []
+                    Constructors = []
+                    Documentation = documentation
+                }
+                |> TypeAliasRender.TypeDefn
+            | ResolvedType.Union _ ->
+                let typeRefRender =
                     {
-                        LiteralUnionRender.Metadata = metadata
+                        TypeAliasRenderRef.Documentation = documentation
+                        Metadata = metadata
                         Name = name
-                        Cases =
-                            enumRender.Cases
-                            |> List.map (fun case ->
-                                {
-                                    LiteralCaseRender.Metadata = case.Metadata
-                                    Name = case.Name.Value
-                                    Value = case.Value
-                                    Documentation = case.Documentation
-                                })
-                        Documentation = documentation
+                        TypeParameters = typeParameters
+                        Type = ctx.PreludeGetTypeRef ctx scopeStore innerType
                     }
-                    |> TypeAliasRender.EnumUnion
-                | TypeRender.StringUnion literalRender ->
-                    {
-                        LiteralUnionRender.Metadata = metadata
-                        Name = name
-                        Cases =
-                            literalRender.Cases
-                            |> List.map (fun case ->
-                                {
-                                    LiteralCaseRender.Metadata = case.Metadata
-                                    Name = case.Name.Value
-                                    Value = case.Value
-                                    Documentation = case.Documentation
-                                })
-                        Documentation = documentation
-                    }
-                    |> TypeAliasRender.StringUnion
-                | _ -> typeRefRender
-            | _ -> typeRefRender
-        | ResolvedType.Literal tsLiteral ->
-            {
-                LiteralUnionRender.Metadata = metadata
-                Name = name
-                Cases = [
-                    {
-                        LiteralCaseRender.Metadata = { Path = Path.create TransientMemberPath.Anchored; Original = Path.create TransientMemberPath.Anchored
-                                                       Source = ValueNone; FullyQualifiedName = ValueNone }
-                        Name = name
-                        Value = tsLiteral
-                        Documentation = documentation
-                    }
-                ]
-                Documentation = documentation
-            }
-            |> TypeAliasRender.StringUnion
-            
-        | ResolvedType.ReadOnly resolvedType ->
-            let members,functions =
-                Member.collectAllRecursively resolvedType
-                |> List.map Member.setReadOnly
-                |> Member.partitionRender ctx scopeStore
-            {
-                TypeLikeRender.Metadata = metadata
-                Name = name
-                TypeParameters = typeParameters
-                Members = members
-                Functions = functions
-                Inheritance = []
-                Constructors = []
-                Documentation = documentation
-            }
-            |> TypeAliasRender.TypeDefn
-        | ResolvedType.EnumCase enumCase ->
-            {
-                LiteralUnionRender.Metadata = metadata
-                Name = name
-                Cases = [
-                    {
-                        LiteralCaseRender.Metadata = {
-                            Path = Path.create TransientMemberPath.Anchored
-                            Original = Path.create TransientMemberPath.Anchored
-                            Source = enumCase.Source |> Option.toValueOption
-                            FullyQualifiedName = ValueSome enumCase.FullyQualifiedName
+                    |> TypeAliasRender.Alias
+                match ResolvedTypeCategories.create innerType.Value with
+                // no literals, and no 'others' that require a transient type
+                | { LiteralLike = literals; Others = []; Nullable = nullable; Primitives = []; EnumLike = [] } ->
+                    match Union.renderLiterals ctx scopeStore literals with
+                    | TypeRender.EnumUnion enumRender ->
+                        {
+                            LiteralUnionRender.Metadata = metadata
+                            Name = name
+                            Cases =
+                                enumRender.Cases
+                                |> List.map (fun case ->
+                                    {
+                                        LiteralCaseRender.Metadata = case.Metadata
+                                        Name = case.Name.Value
+                                        Value = case.Value
+                                        Documentation = case.Documentation
+                                    })
+                            Documentation = documentation
                         }
-                        Name = enumCase.Name
-                        Value = enumCase.Value
-                        Documentation = enumCase.Documentation
-                    }
-                ]
-                Documentation = documentation
-            }
-            |> TypeAliasRender.StringUnion
-        | ResolvedType.TemplateLiteral templateLiteral ->
-            {
-                TypeLikeRender.Metadata = metadata
-                Name = name
-                TypeParameters = typeParameters
-                Members = [
-                    {
-                        TypedNameRender.Metadata = { Path = Path.create TransientMemberPath.Anchored; Original = Path.create TransientMemberPath.Anchored
-                                                     Source = ValueNone; FullyQualifiedName = ValueNone }
-                        Name = Name.create "Value" |> Case.addCamelMeasure
-                        Type =
-                            RenderScopeStore.TypeRefRender.create
-                                scopeStore
-                                (ResolvedType.Primitive TypeKindPrimitive.String)
-                                false
-                                Intrinsic.string 
-                        Traits = Set [ RenderTraits.EmitSelf ]
-                        TypeParameters = []
-                        Documentation = []
-                    }
-                ]
-                Functions = [
-                    {
-                        FunctionLikeRender.Metadata = { Path = Path.create TransientMemberPath.Anchored; Original = Path.create TransientMemberPath.Anchored
-                                                        Source = ValueNone; FullyQualifiedName = ValueNone }
-                        Name = Name.create "Create" |> Case.addCamelMeasure
-                        Signatures = [
-                            {
-                                FunctionLikeSignature.Metadata = { Path = Path.create TransientMemberPath.Anchored; Original = Path.create TransientMemberPath.Anchored
-                                                                   Source = ValueNone; FullyQualifiedName = ValueNone }
-                                Parameters =
-                                    templateLiteral.Types
-                                    |> List.mapi (fun i typeRef ->
-                                        {
-                                            TypedNameRender.Metadata = { Path = Path.create TransientParameterPath.Anchored; Original = Path.create TransientParameterPath.Anchored
-                                                                         Source = ValueNone; FullyQualifiedName = ValueNone }
-                                            Name = Name.Camel.create $"v{i}"
-                                            Type = ctx.PreludeGetTypeRef ctx scopeStore typeRef
-                                            Traits = Set.empty
-                                            TypeParameters = []
-                                            Documentation = []
-                                        }
-                                        )
-                                ReturnType =
-                                    Ast.Anon(Name.Case.valueOrModified name)
-                                    |> RenderScopeStore.TypeRefAtom.Unsafe.createWidget
-                                    |> RenderScopeStore.TypeRef.Unsafe.createAtom
-                                    |> RenderScopeStore.TypeRefRender.Unsafe.createFromKind false
-                                Traits = Set [
-                                    RenderTraits.Inline
-                                    RenderTraits.StringBuilder
-                                ]
-                                TypeParameters = []
-                                Documentation = []
+                        |> TypeAliasRender.EnumUnion
+                    | TypeRender.StringUnion literalRender ->
+                        {
+                            LiteralUnionRender.Metadata = metadata
+                            Name = name
+                            Cases =
+                                literalRender.Cases
+                                |> List.map (fun case ->
+                                    {
+                                        LiteralCaseRender.Metadata = case.Metadata
+                                        Name = case.Name.Value
+                                        Value = case.Value
+                                        Documentation = case.Documentation
+                                    })
+                            Documentation = documentation
+                        }
+                        |> TypeAliasRender.StringUnion
+                    | _ -> typeRefRender
+                | _ -> typeRefRender
+            | ResolvedType.Literal tsLiteral ->
+                {
+                    LiteralUnionRender.Metadata = metadata
+                    Name = name
+                    Cases = [
+                        {
+                            LiteralCaseRender.Metadata = { Path = Path.create TransientMemberPath.Anchored; Original = Path.create TransientMemberPath.Anchored
+                                                           Source = ValueNone; FullyQualifiedName = ValueNone }
+                            Name = name
+                            Value = tsLiteral
+                            Documentation = documentation
+                        }
+                    ]
+                    Documentation = documentation
+                }
+                |> TypeAliasRender.StringUnion
+                
+            | ResolvedType.ReadOnly resolvedType ->
+                let members,functions =
+                    Member.collectAllRecursively resolvedType
+                    |> List.map Member.setReadOnly
+                    |> Member.partitionRender ctx scopeStore
+                {
+                    TypeLikeRender.Metadata = metadata
+                    Name = name
+                    TypeParameters = typeParameters
+                    Members = members
+                    Functions = functions
+                    Inheritance = []
+                    Constructors = []
+                    Documentation = documentation
+                }
+                |> TypeAliasRender.TypeDefn
+            | ResolvedType.EnumCase enumCase ->
+                {
+                    LiteralUnionRender.Metadata = metadata
+                    Name = name
+                    Cases = [
+                        {
+                            LiteralCaseRender.Metadata = {
+                                Path = Path.create TransientMemberPath.Anchored
+                                Original = Path.create TransientMemberPath.Anchored
+                                Source = enumCase.Source |> Option.toValueOption
+                                FullyQualifiedName = ValueSome enumCase.FullyQualifiedName
                             }
-                        ]
-                        Traits = Set [
-                            RenderTraits.Inline
-                            RenderTraits.StringBuilder
-                        ]
-                        TypeParameters = []
-                        Documentation = []
-                    }
-                ]
-                Inheritance = []
-                Constructors = []
-                Documentation = documentation
-            }
-            |> TypeAliasRender.TypeDefn
+                            Name = enumCase.Name
+                            Value = enumCase.Value
+                            Documentation = enumCase.Documentation
+                        }
+                    ]
+                    Documentation = documentation
+                }
+                |> TypeAliasRender.StringUnion
+            | ResolvedType.TemplateLiteral templateLiteral ->
+                {
+                    TypeLikeRender.Metadata = metadata
+                    Name = name
+                    TypeParameters = typeParameters
+                    Members = [
+                        {
+                            TypedNameRender.Metadata = { Path = Path.create TransientMemberPath.Anchored; Original = Path.create TransientMemberPath.Anchored
+                                                         Source = ValueNone; FullyQualifiedName = ValueNone }
+                            Name = Name.create "Value" |> Case.addCamelMeasure
+                            Type =
+                                RenderScopeStore.TypeRefRender.create
+                                    scopeStore
+                                    (ResolvedType.Primitive TypeKindPrimitive.String)
+                                    false
+                                    Intrinsic.string 
+                            Traits = Set [ RenderTraits.EmitSelf ]
+                            TypeParameters = []
+                            Documentation = []
+                        }
+                    ]
+                    Functions = [
+                        {
+                            FunctionLikeRender.Metadata = { Path = Path.create TransientMemberPath.Anchored; Original = Path.create TransientMemberPath.Anchored
+                                                            Source = ValueNone; FullyQualifiedName = ValueNone }
+                            Name = Name.create "Create" |> Case.addCamelMeasure
+                            Signatures = [
+                                {
+                                    FunctionLikeSignature.Metadata = { Path = Path.create TransientMemberPath.Anchored; Original = Path.create TransientMemberPath.Anchored
+                                                                       Source = ValueNone; FullyQualifiedName = ValueNone }
+                                    Parameters =
+                                        templateLiteral.Types
+                                        |> List.mapi (fun i typeRef ->
+                                            {
+                                                TypedNameRender.Metadata = { Path = Path.create TransientParameterPath.Anchored; Original = Path.create TransientParameterPath.Anchored
+                                                                             Source = ValueNone; FullyQualifiedName = ValueNone }
+                                                Name = Name.Camel.create $"v{i}"
+                                                Type = ctx.PreludeGetTypeRef ctx scopeStore typeRef
+                                                Traits = Set.empty
+                                                TypeParameters = []
+                                                Documentation = []
+                                            }
+                                            )
+                                    ReturnType =
+                                        Ast.Anon(Name.Case.valueOrModified name)
+                                        |> RenderScopeStore.TypeRefAtom.Unsafe.createWidget
+                                        |> RenderScopeStore.TypeRef.Unsafe.createAtom
+                                        |> RenderScopeStore.TypeRefRender.Unsafe.createFromKind false
+                                    Traits = Set [
+                                        RenderTraits.Inline
+                                        RenderTraits.StringBuilder
+                                    ]
+                                    TypeParameters = []
+                                    Documentation = []
+                                }
+                            ]
+                            Traits = Set [
+                                RenderTraits.Inline
+                                RenderTraits.StringBuilder
+                            ]
+                            TypeParameters = []
+                            Documentation = []
+                        }
+                    ]
+                    Inheritance = []
+                    Constructors = []
+                    Documentation = documentation
+                }
+                |> TypeAliasRender.TypeDefn
+        matchImpl innerType.Value

--- a/src/Xantham.Generator/Generator/Render.TypeAlias.fs
+++ b/src/Xantham.Generator/Generator/Render.TypeAlias.fs
@@ -23,6 +23,17 @@ module TypeAlias =
         let metadata =
             (Path.create path, typ)
             ||> RenderMetadata.createWithPathFromExport
+        let resolveInnerRef () =
+            let oldRef = ctx.PreludeGetTypeRef ctx scopeStore innerType
+            match ctx.PreludeRenders.TryGetValue(innerType.Value) with
+            | true, newRef ->
+                match ctx.TypeAliasRemap.TryGetValue(innerType.Value) with
+                | true, value ->
+                    let stripped = { oldRef with Nullable = false }
+                    TypeRefRender.replace value newRef.TypeRef stripped
+                    |> TypeRefRender.orNullable oldRef.Nullable
+                | _ -> newRef.TypeRef
+            | false, _ -> oldRef
         let rec matchImpl = function
             | ResolvedType.TypeQuery { Type = Resolve typ } ->
                 matchImpl typ
@@ -41,25 +52,12 @@ module TypeAlias =
             | ResolvedType.Conditional _
             | ResolvedType.Enum _
             | ResolvedType.Array _ ->
-                let oldRef = ctx.PreludeGetTypeRef ctx scopeStore innerType
-                let innerRef =
-                    match ctx.PreludeRenders.TryGetValue(innerType.Value) with
-                    | true, value -> ValueSome value
-                    | false, _ -> ValueNone
-                    |> ValueOption.map (fun newRef ->
-                        match ctx.TypeAliasRemap.TryGetValue(innerType.Value) with
-                        | true, value ->
-                            TypeRefRender.replace value newRef.TypeRef oldRef
-                        | _ -> newRef.TypeRef
-                        )
-                    |> ValueOption.defaultValue oldRef
-                    
                 {
                     TypeAliasRenderRef.Documentation = documentation
                     Metadata = metadata
                     Name = name
                     TypeParameters = typeParameters
-                    Type = innerRef
+                    Type = resolveInnerRef ()
                 }
                 |> TypeAliasRender.Alias
             | ResolvedType.Intersection _ 
@@ -88,7 +86,7 @@ module TypeAlias =
                         Metadata = metadata
                         Name = name
                         TypeParameters = typeParameters
-                        Type = ctx.PreludeGetTypeRef ctx scopeStore innerType
+                        Type = resolveInnerRef ()
                     }
                     |> TypeAliasRender.Alias
                 match ResolvedTypeCategories.create innerType.Value with

--- a/src/Xantham.Generator/Generator/RenderScope.Anchored.fs
+++ b/src/Xantham.Generator/Generator/RenderScope.Anchored.fs
@@ -2,21 +2,17 @@
 module Xantham.Generator.Generator.RenderScope_Anchored
 
 open System.Collections.Generic
-open Xantham
 open Xantham.Decoder
 open Xantham.Decoder.ArenaInterner
 open Xantham.Generator
 open Xantham.Generator.Generator.Path
 open Xantham.Generator.Types
 open Xantham.Generator.NamePath
-open Xantham.Generator.Generator.ResolvedTypeCategorization
 open Xantham.Generator.Generator
-open Fabulous.AST
-open Fantomas.Core.SyntaxOak
 open Anchored
 
 module Render =
-    let anchorMetadataPath (ctx: GeneratorContext) (anchorPath: AnchorPath) (path: Path) =
+    let anchorMetadataPath (_ctx: GeneratorContext) (anchorPath: AnchorPath) (path: Path) =
         match path with
         | Path.Transient transientPath ->
             transientPath

--- a/src/Xantham.Generator/Generator/RenderScope.Prelude.fs
+++ b/src/Xantham.Generator/Generator/RenderScope.Prelude.fs
@@ -12,7 +12,6 @@ open Xantham
 open Xantham.Decoder
 open Xantham.Decoder.ArenaInterner
 open Fabulous.AST
-open Fantomas.Core.SyntaxOak
 open Xantham.Generator.NamePath
 
 let private createConcreteTypeRef (path: TypePath) =
@@ -394,6 +393,10 @@ let rec prerender (ctx: GeneratorContext) (scope: RenderScopeStore) (lazyResolve
         |> LazyContainer.CreateFromValue
         |> prerender ctx scope
         |> TypeRefRender.nullable
+        |> RenderScope.createRootless resolvedType
+        |> addOrReplaceScope ctx resolvedType
+    | ResolvedType.TypeQuery typeQuery ->
+        prerender ctx scope typeQuery.Type
         |> RenderScope.createRootless resolvedType
         |> addOrReplaceScope ctx resolvedType
     | ResolvedType.Substitution substitutionType ->

--- a/src/Xantham.Generator/Generator/ResolvedType.Categorization.fs
+++ b/src/Xantham.Generator/Generator/ResolvedType.Categorization.fs
@@ -8,10 +8,12 @@ open Xantham.Generator
 type ResolvedTypeLiteralLike =
     | EnumCase of EnumCase
     | Literal of TsLiteral
+    | TypeQuery of TypeQuery
     member this.AsResolvedType =
         match this with
         | EnumCase enumCase -> ResolvedType.EnumCase enumCase
         | Literal tsLiteral -> ResolvedType.Literal tsLiteral
+        | TypeQuery typeQuery -> ResolvedType.TypeQuery typeQuery
 
 [<RequireQualifiedAccess>]
 type ResolvedTypeEnumLike =
@@ -67,29 +69,34 @@ type ResolvedTypeCategories = {
 }
 
 module ResolvedTypeCategories =
-    let (|PrimitiveLike|LiteralLike|EnumLike|OtherLike|) = function
-        | ResolvedType.Array resolvedType -> OtherLike (ResolvedTypeOther.Array resolvedType)
-        | ResolvedType.Class resolvedType -> OtherLike (ResolvedTypeOther.Class resolvedType)
-        | ResolvedType.Interface resolvedType -> OtherLike (ResolvedTypeOther.Interface resolvedType)
-        | ResolvedType.GlobalThis -> OtherLike ResolvedTypeOther.GlobalThis
-        | ResolvedType.TypeLiteral resolvedType -> OtherLike (ResolvedTypeOther.TypeLiteral resolvedType)
-        | ResolvedType.TypeParameter resolvedType -> OtherLike (ResolvedTypeOther.TypeParameter resolvedType)
-        | ResolvedType.Tuple resolvedType -> OtherLike (ResolvedTypeOther.Tuple resolvedType)
-        | ResolvedType.TypeReference resolvedType -> OtherLike (ResolvedTypeOther.TypeReference resolvedType)
-        | ResolvedType.IndexedAccess resolvedType -> OtherLike (ResolvedTypeOther.IndexedAccess resolvedType)
-        | ResolvedType.Intersection resolvedType -> OtherLike (ResolvedTypeOther.Intersection resolvedType)
-        | ResolvedType.TemplateLiteral resolvedType -> OtherLike (ResolvedTypeOther.TemplateLiteral resolvedType)
-        | ResolvedType.Predicate resolvedType -> PrimitiveLike (ResolvedTypePrimitiveLike.Predicate resolvedType)
-        | ResolvedType.Primitive resolvedType -> PrimitiveLike (ResolvedTypePrimitiveLike.Primitive resolvedType)
-        | ResolvedType.Enum resolvedType -> EnumLike (ResolvedTypeEnumLike.Enum resolvedType)
-        | ResolvedType.Index resolvedType -> EnumLike (ResolvedTypeEnumLike.Index resolvedType)
-        | ResolvedType.Literal resolvedType -> LiteralLike (ResolvedTypeLiteralLike.Literal resolvedType)
-        | ResolvedType.EnumCase resolvedType -> LiteralLike (ResolvedTypeLiteralLike.EnumCase resolvedType)
-        | ResolvedType.Conditional _
-        | ResolvedType.Union _
-        | ResolvedType.ReadOnly _
-        | ResolvedType.Optional _
-        | ResolvedType.Substitution _ -> invalidOp "These operations are only available for expanded resolved types in the ResolvedTypeCategories module"
+    let (|PrimitiveLike|LiteralLike|EnumLike|OtherLike|) =
+        let rec impl = function
+            | ResolvedType.Array resolvedType -> OtherLike (ResolvedTypeOther.Array resolvedType)
+            | ResolvedType.Class resolvedType -> OtherLike (ResolvedTypeOther.Class resolvedType)
+            | ResolvedType.Interface resolvedType -> OtherLike (ResolvedTypeOther.Interface resolvedType)
+            | ResolvedType.GlobalThis -> OtherLike ResolvedTypeOther.GlobalThis
+            | ResolvedType.TypeLiteral resolvedType -> OtherLike (ResolvedTypeOther.TypeLiteral resolvedType)
+            | ResolvedType.TypeParameter resolvedType -> OtherLike (ResolvedTypeOther.TypeParameter resolvedType)
+            | ResolvedType.Tuple resolvedType -> OtherLike (ResolvedTypeOther.Tuple resolvedType)
+            | ResolvedType.TypeReference resolvedType -> OtherLike (ResolvedTypeOther.TypeReference resolvedType)
+            | ResolvedType.IndexedAccess resolvedType -> OtherLike (ResolvedTypeOther.IndexedAccess resolvedType)
+            | ResolvedType.Intersection resolvedType -> OtherLike (ResolvedTypeOther.Intersection resolvedType)
+            | ResolvedType.TemplateLiteral resolvedType -> OtherLike (ResolvedTypeOther.TemplateLiteral resolvedType)
+            | ResolvedType.Predicate resolvedType -> PrimitiveLike (ResolvedTypePrimitiveLike.Predicate resolvedType)
+            | ResolvedType.Primitive resolvedType -> PrimitiveLike (ResolvedTypePrimitiveLike.Primitive resolvedType)
+            | ResolvedType.Enum resolvedType -> EnumLike (ResolvedTypeEnumLike.Enum resolvedType)
+            | ResolvedType.Index resolvedType -> EnumLike (ResolvedTypeEnumLike.Index resolvedType)
+            | ResolvedType.Literal resolvedType -> LiteralLike (ResolvedTypeLiteralLike.Literal resolvedType)
+            | ResolvedType.EnumCase resolvedType -> LiteralLike (ResolvedTypeLiteralLike.EnumCase resolvedType)
+            | ResolvedType.TypeQuery ({ Type = Resolve (ResolvedType.Literal _) } as resolvedType) -> LiteralLike (ResolvedTypeLiteralLike.TypeQuery resolvedType)
+            | ResolvedType.TypeQuery { Type = Resolve typ } -> impl typ
+            | ResolvedType.Conditional _
+            | ResolvedType.Union _
+            | ResolvedType.ReadOnly _
+            | ResolvedType.Optional _
+            | ResolvedType.Substitution _ -> invalidOp "These operations are only available for expanded resolved types in the ResolvedTypeCategories module"
+
+        impl
     let inline (|AsResolvedType|) (value: ^T when ^T:(member AsResolvedType: ResolvedType)) = value.AsResolvedType
 
     let empty = {

--- a/tests/Xantham.Fable.Tests/Program.fs
+++ b/tests/Xantham.Fable.Tests/Program.fs
@@ -661,6 +661,58 @@ let unionTests =
             match result |> findType threeWay.Type with
             | TsType.Union u -> "" |> Expect.hasLength u.Types 3
             | _ -> failwith "Expected Union"
+        
+        testList "Union of const typeof's" [
+            testCase "Union 'RGBAFormat' is present with 3 members" <| fun _ ->
+                let format = findAlias "RGBAFormat" result
+                match findType format.Type result with
+                | TsType.Union x -> "" |> Expect.hasLength x.Types 3
+                | _ -> failwith "Expected Union"
+            
+            testCase "All 3 variables present" <| fun _ ->
+                Expect.hasLength [
+                    findVariable "RGBA1_Format" result
+                    findVariable "RGBA2_Format" result
+                    findVariable "RGBA3_Format" result
+                ] 3 ""
+            
+            testCase "Type of each variable is a literal" <| fun _ ->
+                let vars = [
+                    findVariable "RGBA1_Format" result
+                    findVariable "RGBA2_Format" result
+                    findVariable "RGBA3_Format" result
+                ]
+                vars
+                |> List.forall (fun v ->
+                    match findType v.Type result with
+                    | TsType.Literal _ -> true
+                    | _ -> false
+                    )
+                |> Expect.isTrue
+                |> funApply ""
+                vars
+                |> List.choose (fun v ->
+                    match findType v.Type result with
+                    | TsType.Literal (TsLiteral.Int i) -> Some i
+                    | _ -> None)
+                |> Expect.containsAll
+                |> funApply [ 1; 2; 3 ]
+                |> funApply ""
+            testCase "Type of each variable equals union" <| fun _ ->
+                [
+                    findVariable "RGBA1_Format" result
+                    findVariable "RGBA2_Format" result
+                    findVariable "RGBA3_Format" result
+                ]
+                |> List.map _.Type
+                |> Expect.containsAll (match (findType (findAlias "RGBAFormat" result).Type result) with TsType.Union u -> u.Types | _ -> [])
+                |> funApply ""
+                
+                
+            
+                
+                
+        ]
     ]
 
 // -----------------------------------------------------------------------

--- a/tests/Xantham.Fable.Tests/Program.fs
+++ b/tests/Xantham.Fable.Tests/Program.fs
@@ -1,12 +1,10 @@
 module Main
 
-open System.Collections.Generic
 open Xantham
 open Xantham.Fable
 open Xantham.Fable.Types
 open Node.Api
 open Fable.Mocha
-open Fable.Core.Testing
 open Xantham.Schema
 
 // -----------------------------------------------------------------------
@@ -53,7 +51,7 @@ let tryFindInterface name (result: EncodedResult) =
 /// Find the first interface in the result whose Name matches; throws on miss.
 let findInterface name result =
     tryFindInterface name result
-    |> Option.defaultWith (fun () -> failwithf "Interface '%s' not found in result" name)
+    |> Option.defaultWith (fun () -> failwithf $"Interface '%s{name}' not found in result")
 
 /// Find the first enum whose Name matches; throws on miss.
 let findEnum name (result: EncodedResult) =
@@ -322,7 +320,7 @@ let memberTests =
 
         testCase "'greet' parameter is named 'message'" <| fun _ ->
             let m = findInterface "WithMethods" result |> _.Members |> findMethod "greet"
-            let p = m.ValueOrHead.Parameters.[0]
+            let p = m.ValueOrHead.Parameters[0]
             "greet param should be named message" |> Expect.equal p.Name "message"
 
         testCase "'add' method has 2 parameters" <| fun _ ->
@@ -493,7 +491,7 @@ let genericsTests =
 
         testCase "'Box' type parameter is named 'T'" <| fun _ ->
             let iface = result |> findInterface "Box"
-            let (_, tp) = iface.TypeParameters.[0]
+            let _, tp = iface.TypeParameters[0]
             "Box type param should be T" |> Expect.equal tp.Name "T"
 
         testCase "'Box' has a member named 'value'" <| fun _ ->
@@ -551,13 +549,13 @@ let functionTests =
 
         testCase "'collect' parameter 'items' is a spread (rest) param" <| fun _ ->
             let fd = fd |> findFunction "collect"
-            let p = fd.ValueOrHead.Parameters.[0]
+            let p = fd.ValueOrHead.Parameters[0]
             "items should be spread" |> Expect.isTrue p.IsSpread
 
         testCase "'collect' spread parameter 'items' is not optional" <| fun _ ->
             // Rest parameters cannot be optional in TypeScript
             let fd = fd |> findFunction "collect"
-            let p = fd.ValueOrHead.Parameters.[0]
+            let p = fd.ValueOrHead.Parameters[0]
             "items should not be optional" |> Expect.isFalse p.IsOptional
 
         testCase "'ping' has 0 parameters" <| fun _ ->
@@ -698,18 +696,14 @@ let unionTests =
                 |> Expect.containsAll
                 |> funApply [ 1; 2; 3 ]
                 |> funApply ""
-            testCase "Type of each variable equals union" <| fun _ ->
-                [
-                    findVariable "RGBA1_Format" result
-                    findVariable "RGBA2_Format" result
-                    findVariable "RGBA3_Format" result
-                ]
-                |> List.map _.Type
-                |> Expect.containsAll (match (findType (findAlias "RGBAFormat" result).Type result) with TsType.Union u -> u.Types | _ -> [])
-                |> funApply ""
-                
-                
-            
+            testCase "Type of union types is TypeQuery" <| fun _ ->
+                let format = findAlias "RGBAFormat" result
+                match findType format.Type result with
+                | TsType.Union x ->
+                    for typ in x.Types do
+                        "All types in union should be TypeQuery"
+                        |> Expect.isTrue (findType typ result).IsTypeQuery
+                | _ -> failwith "Expected Union"
                 
                 
         ]
@@ -830,10 +824,10 @@ let classTests =
             "" |> Expect.hasLength cls.Constructors 1
 
         testCase "'Animal' constructor has 2 parameters" <| fun _ ->
-            "" |> Expect.hasLength cls.Constructors.[0].Parameters 2
+            "" |> Expect.hasLength cls.Constructors[0].Parameters 2
 
         testCase "'Animal' constructor parameter names are 'name' and 'age'" <| fun _ ->
-            let names = cls.Constructors.[0].Parameters |> List.map _.Name
+            let names = cls.Constructors[0].Parameters |> List.map _.Name
             "" |> Expect.containsAll names [ "name"; "age" ]
 
         testCase "'Animal' has a 'speak' method member" <| fun _ ->
@@ -1280,7 +1274,7 @@ let templateLiteralTests =
 
         testCase "'EventName' interpolated type is string primitive" <| fun _ ->
             match result |> findType eventAlias.Type with
-            | TsType.TemplateLiteral t -> "" |> Expect.equal t.Types.[0] TypeKindPrimitive.String.TypeKey
+            | TsType.TemplateLiteral t -> "" |> Expect.equal t.Types[0] TypeKindPrimitive.String.TypeKey
             | _ -> failwith "Expected TemplateLiteral"
 
         testCase "'KeyValuePair' has 2 interpolated Type entries" <| fun _ ->
@@ -1294,7 +1288,7 @@ let templateLiteralTests =
             match result |> findType kv.Type with
             | TsType.TemplateLiteral t ->
                 // texts = [""; ":"; ""] — index 1 is the separator between the two interpolations
-                "" |> Expect.equal t.Texts.[1] ":"
+                "" |> Expect.equal t.Texts[1] ":"
             | _ -> failwith "Expected TemplateLiteral"
     ]
 
@@ -1415,11 +1409,11 @@ let functionRefTests =
 
         testCase "'getPerson' parameter is named 'name'" <| fun _ ->
             let fn = result |> findFunction "getPerson"
-            "" |> Expect.equal fn.ValueOrHead.Parameters.[0].Name "name"
+            "" |> Expect.equal fn.ValueOrHead.Parameters[0].Name "name"
 
         testCase "'getPerson' parameter 'name' is type string" <| fun _ ->
             let fn = result |> findFunction "getPerson"
-            "" |> Expect.equal fn.ValueOrHead.Parameters.[0].Type TypeKindPrimitive.String.TypeKey
+            "" |> Expect.equal fn.ValueOrHead.Parameters[0].Type TypeKindPrimitive.String.TypeKey
 
         testCase "'Api' interface is present" <| fun _ ->
             "'Api' should be in result"
@@ -1435,42 +1429,57 @@ let functionRefTests =
                 | TsMember.Property p when p.Name = "person" -> true
                 | _ -> false)
 
-        testCase "'Api.person' type resolves to TypeLiteral (typeof getPerson)" <| fun _ ->
+        testCase "'Api.person' type resolves to TypeQuery - TypeLiteral (typeof getPerson)" <| fun _ ->
             let prop = api.Members |> findProperty "person"
             let typ = result |> findType prop.Type
+            "'Api.person' should be a TypeQuery"
+            |> Expect.isTrue (match typ with TsType.TypeQuery _ -> true | _ -> false)
+            let typ =
+                match typ with
+                | TsType.TypeQuery t -> findType t.Type result
+                | _ -> failwith "Expected TypeQuery"
             "typeof getPerson should be a TypeLiteral (anonymous function type)"
             |> Expect.isTrue (match typ with TsType.TypeLiteral _ -> true | _ -> false)
 
         testCase "'Api.person' TypeLiteral has exactly 1 CallSignature" <| fun _ ->
             let prop = api.Members |> findProperty "person"
             match result |> findType prop.Type with
-            | TsType.TypeLiteral { Members = members } ->
-                let callSigs = members |> List.filter (function TsMember.CallSignature _ -> true | _ -> false)
-                "" |> Expect.hasLength callSigs 1
-            | _ -> failwith "Expected TypeLiteral"
+            | TsType.TypeQuery { Type = typ } ->
+                match result |> findType typ with
+                | TsType.TypeLiteral { Members = members } ->
+                    let callSigs = members |> List.filter (function TsMember.CallSignature _ -> true | _ -> false)
+                    "" |> Expect.hasLength callSigs 1
+                | _ -> failwith "Expected TypeLiteral"
+            | _ -> failwith "Expected TypeQuery"
 
         testCase "'Api.person' call signature has 1 parameter named 'name'" <| fun _ ->
             let prop = api.Members |> findProperty "person"
             match result |> findType prop.Type with
-            | TsType.TypeLiteral { Members = members } ->
-                match members |> List.pick (function TsMember.CallSignature c -> Some c | _ -> None) with
-                | TsOverloadableConstruct.NoOverloads cs ->
-                    "" |> Expect.hasLength cs.Parameters 1
-                    "" |> Expect.equal cs.Parameters.[0].Name "name"
-                | _ -> failwith "Expected NoOverloads call signature"
-            | _ -> failwith "Expected TypeLiteral"
+            | TsType.TypeQuery { Type = typ } ->
+                match result |> findType typ with
+                | TsType.TypeLiteral { Members = members } ->
+                    match members |> List.pick (function TsMember.CallSignature c -> Some c | _ -> None) with
+                    | TsOverloadableConstruct.NoOverloads cs ->
+                        "" |> Expect.hasLength cs.Parameters 1
+                        "" |> Expect.equal cs.Parameters[0].Name "name"
+                    | _ -> failwith "Expected NoOverloads call signature"
+                | _ -> failwith "Expected TypeLiteral"
+            | _ -> failwith "Expected TypeQuery"
 
         testCase "'Api.person' call signature return type is NonPrimitive (object)" <| fun _ ->
             let prop = api.Members |> findProperty "person"
             match result |> findType prop.Type with
-            | TsType.TypeLiteral { Members = members } ->
-                match members |> List.pick (function TsMember.CallSignature c -> Some c | _ -> None) with
-                | TsOverloadableConstruct.NoOverloads cs ->
-                    let returnType = result |> findType cs.Type
-                    "Return type of getPerson is 'object' → NonPrimitive"
-                    |> Expect.equal returnType (TsType.Primitive TypeKindPrimitive.NonPrimitive)
-                | _ -> failwith "Expected NoOverloads"
-            | _ -> failwith "Expected TypeLiteral"
+            | TsType.TypeQuery { Type = typ } ->
+                match result |> findType typ with
+                | TsType.TypeLiteral { Members = members } ->
+                    match members |> List.pick (function TsMember.CallSignature c -> Some c | _ -> None) with
+                    | TsOverloadableConstruct.NoOverloads cs ->
+                        let returnType = result |> findType cs.Type
+                        "Return type of getPerson is 'object' → NonPrimitive"
+                        |> Expect.equal returnType (TsType.Primitive TypeKindPrimitive.NonPrimitive)
+                    | _ -> failwith "Expected NoOverloads"
+                | _ -> failwith "Expected TypeLiteral"
+            | _ -> failwith "Expected TypeQuery"
     ]
 
 let multiFileTests =

--- a/tests/Xantham.Fable.Tests/TypeFiles/union.d.ts
+++ b/tests/Xantham.Fable.Tests/TypeFiles/union.d.ts
@@ -8,3 +8,12 @@
 
 export type StringOrNumber = string | number;
 export type ThreeWay = string | number | null;
+
+export const RGBA1_Format = 1;
+export const RGBA2_Format = 2;
+export const RGBA3_Format = 3;
+
+export type RGBAFormat =
+    | typeof RGBA1_Format
+    | typeof RGBA2_Format
+    | typeof RGBA3_Format;


### PR DESCRIPTION
___This is a breaking change___

This adds a new TsType, - TsTypeQuery.

It serves to wrap a `typeof T` and provide the identifier with the type.

The same type graph is achieved by chasing the internal `Type` field of the `TsTypeQuery` record. The identifier provides context that can be valuable for creating literal unions.

This fixes #42 