### PR TITLE
fix: wire exportdeclaration to feed back into export specifiers (Fixes #53 )

### DIFF
--- a/src/Xantham.Fable/Reading/Dispatch/ModulesAndExports.fs
+++ b/src/Xantham.Fable/Reading/Dispatch/ModulesAndExports.fs
@@ -75,9 +75,66 @@ let dispatch (ctx: TypeScriptReader) (xanTag: XanthamTag) (tag: ModulesAndExport
         | None -> Log.error "failed to get symbol"
     | ModulesAndExports.AssertClause _ -> nameof ModulesAndExports.AssertClause |> debugLocation
     | ModulesAndExports.ExportAssignment _ -> nameof ModulesAndExports.ExportAssignment |> debugLocation
-    | ModulesAndExports.ExportDeclaration _ -> nameof ModulesAndExports.ExportDeclaration |> debugLocation
+    // TODO: Export declaration has to be reviewed, temporary patch wires the declarations in most common
+    //       path and renames them appropriately
+    | ModulesAndExports.ExportDeclaration exportDeclaration ->
+        nameof ModulesAndExports.ExportDeclaration |> debugLocation
+        let exportClause = exportDeclaration.exportClause
+        match exportClause with
+        | Some exportClause ->
+            match exportClause with
+            | Patterns.Node.NamedExportBindingsPatterns.NamedExports namedExports ->
+                let namedTags =
+                    namedExports.elements
+                    |> _.AsArray
+                    |> Array.map (ctx.CreateXanthamTag >> fst >> stackPushAndThen ctx (XanthamTag.chainDebug xanTag))
+                namedTags
+                |> Array.tryHead
+                |> Option.iter (fun tag ->
+                    GuardedData.AstNodeBuilder.getOrSetDefault xanTag
+                    |> Signal.fulfillWith(fun () -> tag.Builder.Value)
+                    GuardedData.TypeSignal.getOrSetDefault xanTag
+                    |> Signal.fulfillWith(fun () -> tag.TypeSignal.Value)
+                    GuardedData.ExportBuilder.getOrSetDefault xanTag
+                    |> Signal.fulfillWith(fun () -> tag.ExportBuilder.Value)
+                    )
+            | Patterns.Node.NamedExportBindingsPatterns.NamespaceExport namespaceExport ->
+                match namespaceExport.name with
+                | Patterns.Node.ModuleNamePatterns.Identifier name ->
+                    ctx.checker.getSymbolAtLocation name
+                    |> Option.map (fun symbol ->
+                        if symbol.flags.HasFlag Ts.SymbolFlags.Alias
+                        then ctx.checker.getAliasedSymbol symbol
+                        else symbol)
+                    |> function
+                        | Some symbol ->
+                            let declarations =
+                                symbol.declarations
+                                |> Option.map (
+                                    _.AsArray
+                                    >> Array.map ( ctx.CreateXanthamTag >> fst >> stackPushAndThen ctx (fun tag ->
+                                        if GuardedData.Source.Keyed.has xanTag then
+                                            tag
+                                            |> GuardedData.Source.Keyed.getOrSetWith(fun _ -> Signal.source <| ModuleName "")
+                                            |> Signal.fulfillWith(fun _ -> GuardedData.Source.Keyed.get xanTag |> _.Value)
+                                        tag))
+                                    )
+                                |> Option.defaultValue [||]
+                            match declarations with
+                            | [||] -> ()
+                            | _ -> 
+                                let decl = declarations[0]
+                                xanTag.Builder
+                                |> Signal.fulfillWith (fun () -> decl.Builder.Value)
+                                xanTag.ExportBuilder
+                                |> Signal.fulfillWith (fun () -> decl.ExportBuilder.Value)
+                        | None -> Log.error "failed to get symbol"
+                    | _ -> ()
+        | _ -> ()
+                
     | ModulesAndExports.ExportSpecifier exportSpecifier ->
         nameof ModulesAndExports.ExportSpecifier |> debugLocation
+        
         let source =
             xanTag
             |> GuardedData.Source.getOrSetWith (fun () -> Signal.source <| ctx.moduleMap.Item(exportSpecifier.getSourceFile()))
@@ -109,9 +166,69 @@ let dispatch (ctx: TypeScriptReader) (xanTag: XanthamTag) (tag: ModulesAndExport
                 xanTag.TypeSignal
                 |> Signal.fulfillWith (fun () -> decl.TypeSignal.Value)
                 xanTag.Builder
-                |> Signal.fulfillWith (fun () -> decl.Builder.Value)
+                |> Signal.fulfillWith (fun () ->
+                    if exportSpecifier.propertyName.IsSome then
+                        let name = NameHelpers.getName exportSpecifier.name
+                        decl.Builder.Value
+                        |> ValueOption.map (function
+                            | SType.Class sclass ->
+                                sclass.FullyQualifiedName[sclass.FullyQualifiedName.Length - 1] <- name
+                                { sclass with Name = name }
+                                |> SType.Class
+                            | SType.Interface sInterfaceBuilder ->
+                                sInterfaceBuilder.FullyQualifiedName[sInterfaceBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sInterfaceBuilder with Name = name }
+                                |> SType.Interface
+                            | SType.Enum sEnumTypeBuilder ->
+                                sEnumTypeBuilder.FullyQualifiedName[sEnumTypeBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sEnumTypeBuilder with Name = name }
+                                |> SType.Enum
+                            | SType.EnumCase sEnumCaseBuilder ->
+                                sEnumCaseBuilder.FullyQualifiedName[sEnumCaseBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sEnumCaseBuilder with Name = name }
+                                |> SType.EnumCase
+                            | s -> s
+                            )
+                    else
+                    decl.Builder.Value
+                    )
                 xanTag.ExportBuilder
-                |> Signal.fulfillWith (fun () -> decl.ExportBuilder.Value)
+                |> Signal.fulfillWith (fun () ->
+                    if exportSpecifier.propertyName.IsSome then
+                        let name = NameHelpers.getName exportSpecifier.name
+                        decl.ExportBuilder.Value
+                        |> ValueOption.map (function
+                            | STsExportDeclaration.Variable var ->
+                                var.FullyQualifiedName[var.FullyQualifiedName.Length - 1] <- name
+                                { var with Name = name }
+                                |> STsExportDeclaration.Variable
+                            | STsExportDeclaration.Interface sInterfaceBuilder ->
+                                sInterfaceBuilder.FullyQualifiedName[sInterfaceBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sInterfaceBuilder with Name = name }
+                                |> STsExportDeclaration.Interface
+                            | STsExportDeclaration.Class sClassBuilder ->
+                                sClassBuilder.FullyQualifiedName[sClassBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sClassBuilder with Name = name }
+                                |> STsExportDeclaration.Class
+                            | STsExportDeclaration.Enum sEnumTypeBuilder ->
+                                sEnumTypeBuilder.FullyQualifiedName[sEnumTypeBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sEnumTypeBuilder with Name = name }
+                                |> STsExportDeclaration.Enum
+                            | STsExportDeclaration.Function sFunctionBuilder ->
+                                sFunctionBuilder.FullyQualifiedName[sFunctionBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sFunctionBuilder with Name = name }
+                                |> STsExportDeclaration.Function
+                            | STsExportDeclaration.TypeAlias sAliasBuilder ->
+                                sAliasBuilder.FullyQualifiedName[sAliasBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sAliasBuilder with Name = name }
+                                |> STsExportDeclaration.TypeAlias
+                            | STsExportDeclaration.Module sModuleBuilder ->
+                                sModuleBuilder.FullyQualifiedName[sModuleBuilder.FullyQualifiedName.Length - 1] <- name
+                                { sModuleBuilder with Name = name }
+                                |> STsExportDeclaration.Module)
+                    else
+                    decl.ExportBuilder.Value
+                    )
         | None -> Log.error "failed to get symbol"
     | ModulesAndExports.NamedExports _ -> nameof ModulesAndExports.NamedExports |> debugLocation
     | ModulesAndExports.NamespaceExport _ -> nameof ModulesAndExports.NamespaceExport |> debugLocation

--- a/tests/Xantham.Fable.Tests/Program.fs
+++ b/tests/Xantham.Fable.Tests/Program.fs
@@ -2277,7 +2277,17 @@ let intrinsicTests = testList "intrinsic.d.ts" [
         Expect.hasLength inputTypeRef.TypeArguments 1 "inputExamples type has one type argument"
     }
 ]
-    
+
+// fixture: cloudflare-export
+let cloudFlareExportTests = testList "cloudflare-export.d.ts" [
+    let result = createTestReader "cloudflare-export" |> runReader
+    test "connect exists" {
+        findFunction "connect" result
+        |> _.Values
+        |> Expect.isNotEmpty
+        |> funApply "connect exists"
+    }
+]
 
 // -----------------------------------------------------------------------
 // Suite
@@ -2332,6 +2342,7 @@ let tests =
         nestedGenericsTests
         typeArgsTests
         intrinsicTests
+        cloudFlareExportTests
     ]
 
 Mocha.runTests tests |> ignore

--- a/tests/Xantham.Fable.Tests/TypeFiles/cloudflare-export.d.ts
+++ b/tests/Xantham.Fable.Tests/TypeFiles/cloudflare-export.d.ts
@@ -1,0 +1,7 @@
+﻿declare module "cloudflare:sockets" {
+    function _connect(
+        address: string | any,
+        options?: any,
+    ): any;
+    export { _connect as connect };
+}

--- a/tests/Xantham.Fable.Tests/Xantham.Fable.Tests.fsproj
+++ b/tests/Xantham.Fable.Tests/Xantham.Fable.Tests.fsproj
@@ -61,6 +61,7 @@
         <TypeScriptCompile Include="TypeFiles\type-args.d.ts" />
         <TypeScriptCompile Include="TypeFiles\plan-a-test.d.ts" />
         <TypeScriptCompile Include="TypeFiles\intrinsic.d.ts" />
+        <TypeScriptCompile Include="TypeFiles\cloudflare-export.d.ts" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# Issue

The tag kind ExportDeclaration hadn't been dealt with in previous type encodings.

# Fix

The node is naively wired in.

The important fix is that export specifiers rename their builders to match the exported name instead of the local name.

Test `cloudflare-export.d.ts` verifies this.