### PR TITLE
dedupe rendered signatures from duplicate Function exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ riderModule.iml
 /_ReSharper.Caches/
 *.fs.js
 /fable_modules/
+/node_modules/

--- a/src/Xantham.Generator/Generator/RenderScope.Anchored.fs
+++ b/src/Xantham.Generator/Generator/RenderScope.Anchored.fs
@@ -666,6 +666,7 @@ let rec registerAnchorFromExport (ctx: GeneratorContext) (export: ResolvedExport
                                     )
                         }
                         )
+                    |> List.distinct
                 Traits = Set []
                 TypeParameters =
                     headFunc.TypeParameters

--- a/tests/Xantham.Generator.Tests/Mocking/Arena.Interner.Types.fs
+++ b/tests/Xantham.Generator.Tests/Mocking/Arena.Interner.Types.fs
@@ -189,6 +189,25 @@ module ResolvedType =
         }
         let withParameters parameters callSignature = { callSignature with CallSignature.Parameters = parameters }
         let withReturnType returnType callSignature = { callSignature with CallSignature.Type = LazyContainer.CreateFromValue returnType }
+    module Function =
+        let create name returnType =
+            {
+                IsLibEs = false
+                Source = None
+                FullyQualifiedName = [ QualifiedNamePart.Normal name ]
+                Documentation = []
+                IsDeclared = false
+                Function.Name = Name.Camel.create name
+                Type = LazyContainer.CreateFromValue returnType
+                Parameters = []
+                TypeParameters = []
+                SignatureKey = Lazy.CreateFromValue { TypeLiteral.Members = [] }
+            }
+        let withPath modules func =
+            { func with Function.FullyQualifiedName = (List.map QualifiedNamePart.Normal modules) @ func.FullyQualifiedName }
+        let withParameters parameters func = { func with Function.Parameters = parameters }
+        let withReturnType returnType func = { func with Function.Type = LazyContainer.CreateFromValue returnType }
+
     module TypeReference =
         let wrap = ResolvedType.TypeReference
         let create typ = {

--- a/tests/Xantham.Generator.Tests/Tests/RenderScopeAnchored.fs
+++ b/tests/Xantham.Generator.Tests/Tests/RenderScopeAnchored.fs
@@ -1,0 +1,77 @@
+module Xantham.Generator.Tests.Tests.RenderScopeAnchored
+
+open Expecto
+open Xantham
+open Xantham.Decoder
+open Xantham.Decoder.ArenaInterner
+open Xantham.Generator
+open Xantham.Generator.Generator
+open Xantham.Generator.Types
+open Mocking.ArenaInterner.ResolvedType
+
+// After upstream PR #55 wired exportdeclaration into export specifiers, a
+// renamed re-export (`dispatcherBindingImpl as _dispatcherBindingImpl`) and the
+// canonical declaration both flow into a single `ResolvedExport.Function` as a
+// list of two reference-different Function records with structurally identical
+// rendered signatures. Because Function carries [<ReferenceEquality>],
+// List.distinct on the funcs themselves doesn't dedup; only the resulting
+// FunctionLikeSignature records (plain F# records → structural equality) are
+// deduplicable. Visible symptom: duplicate `_dispatcherBindingImpl` static
+// member in dynamic-workflows.fs. Fix: List.distinct on the constructed
+// Signatures list inside `registerAnchorFromExport`.
+
+[<Tests>]
+let tests =
+    testList "registerAnchorFromExport — Function dedup" [
+        testCase "two reference-different Functions with same content collapse to one signature" <| fun _ ->
+            let ctx = GeneratorContext.Empty
+            // Two structurally identical Function values, different references
+            // (mirrors the post-#55 case where canonical and renamed export
+            // bind to the same shape).
+            let func1 = Function.create "doThing" (primitive TypeKindPrimitive.String)
+            let func2 = Function.create "doThing" (primitive TypeKindPrimitive.String)
+            // Confirm they are reference-different but structurally equal in
+            // the resulting paths (sanity: this is the regression scenario)
+            Expect.isFalse (System.Object.ReferenceEquals(func1, func2))
+                "test mocks must produce reference-different Function records"
+            let export = ResolvedExport.Function [ func1; func2 ]
+            registerAnchorFromExport ctx export
+            // Find the registered FunctionLikeRender for this export.
+            let renderScope =
+                ctx.AnchorRenders
+                |> Seq.choose (function
+                    | KeyValue(_, Choice2Of2 scope) -> Some scope
+                    | _ -> None)
+                |> Seq.tryHead
+            match renderScope with
+            | None -> failtest "expected a render scope to be registered"
+            | Some scope ->
+                match snd scope.Render |> _.Value with
+                | Anchored.TypeRender.Function functionLike ->
+                    Flip.Expect.equal
+                        "two duplicate input funcs should collapse to a single signature"
+                        1
+                        functionLike.Signatures.Length
+                | other ->
+                    failtestf "expected TypeRender.Function but got %A" other
+
+        testCase "single Function produces one signature (baseline)" <| fun _ ->
+            let ctx = GeneratorContext.Empty
+            let func = Function.create "doThing" (primitive TypeKindPrimitive.String)
+            let export = ResolvedExport.Function [ func ]
+            registerAnchorFromExport ctx export
+            let renderScope =
+                ctx.AnchorRenders
+                |> Seq.choose (function
+                    | KeyValue(_, Choice2Of2 scope) -> Some scope
+                    | _ -> None)
+                |> Seq.tryHead
+            match renderScope with
+            | None -> failtest "expected a render scope to be registered"
+            | Some scope ->
+                match snd scope.Render |> _.Value with
+                | Anchored.TypeRender.Function functionLike ->
+                    Flip.Expect.equal "single func → single signature" 1 functionLike.Signatures.Length
+                | other ->
+                    failtestf "expected TypeRender.Function but got %A" other
+    ]

--- a/tests/Xantham.Generator.Tests/Xantham.Generator.Tests.fsproj
+++ b/tests/Xantham.Generator.Tests/Xantham.Generator.Tests.fsproj
@@ -17,6 +17,7 @@
         <Compile Include="Tests\NamePath.fs" />
         <Compile Include="Tests\TypeRefRender.EncoderInvariant.fs" />
         <Compile Include="Tests\TypeRefRender.SubstituteForHeritage.fs" />
+        <Compile Include="Tests\RenderScopeAnchored.fs" />
         <Compile Include="Main.fs"/>
     </ItemGroup>
 


### PR DESCRIPTION
After #55 wired exportdeclaration into export specifiers, a renamed
re-export and the canonical declaration both flow into a single
ResolvedExport.Function as a list of two reference-different Function
records (Function carries [<ReferenceEquality>]) with structurally
identical rendered signatures. List.distinct on the resulting
FunctionLikeSignature list deduplicates them, since FunctionLikeSignature
uses default structural equality. Visible symptom: duplicate
_dispatcherBindingImpl static member in dynamic-workflows.fs.