### PR TITLE
stop recursing into new' in TypeRefRender.replace (issue #39 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ riderModule.iml
 /_ReSharper.Caches/
 *.fs.js
 /fable_modules/
+/node_modules/

--- a/src/Xantham.Generator/Types/RenderScope.Prelude.fs
+++ b/src/Xantham.Generator/Types/RenderScope.Prelude.fs
@@ -94,7 +94,7 @@ module TypeRefRender =
             )
     let rec replace (old: TypeRefRender) (new': TypeRefRender) (render: TypeRefRender) =
         if old = new' then render
-        elif render = old then replace old new' new'
+        elif render = old then new'
         elif render.Kind.IsMolecule_ then
             let kind =
                 match render.Kind with

--- a/tests/Xantham.Generator.Tests/Tests/TypeAliasRender.fs
+++ b/tests/Xantham.Generator.Tests/Tests/TypeAliasRender.fs
@@ -48,6 +48,29 @@ let typeRefReplaceTests =
             let strRef = TestHelper.prerender ctx (primitive TypeKindPrimitive.String)
             TypeRefRender.replace strRef strRef strRef
             |> Flip.Expect.equal "" strRef
+
+        // Encountered with the agents and workers-types packages: when the
+        // substitution target (`new'`) contains the value being substituted
+        // (`old`) — e.g. old=A, new'=Union<A,B> — the previous code recursed
+        // into new' via `replace old new' new'`, which immediately re-entered
+        // the same case for new's inner A, looping forever. Fix: when
+        // render = old, return new' without further recursion. The substitute
+        // is the value to insert verbatim; sub-references inside it are not
+        // additional substitution opportunities.
+        testCase "replace returns new' verbatim when render = old and new' contains old" <| fun _ ->
+            let strRef = TestHelper.prerender ctx (primitive TypeKindPrimitive.String)
+            let unionContainingStr =
+                TestHelper.prerender ctx (
+                    Union.create [
+                        primitive TypeKindPrimitive.String
+                        primitive TypeKindPrimitive.Integer
+                    ])
+            // Pre-condition sanity: new' really does contain old structurally.
+            // (If this changes, the test is no longer covering the regression.)
+            Expect.notEqual unionContainingStr strRef
+                "new' must be different from old to exercise the second guard"
+            TypeRefRender.replace strRef unionContainingStr strRef
+            |> Flip.Expect.equal "" unionContainingStr
     ]
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
When render = old, the previous code called `replace old new' new'`,
recursing into new' looking for further occurrences of old. If new'
itself contained old (e.g. old=A, new'=Union<A,B>), the recursion
re-entered the same case for new's inner A and looped indefinitely,
causing a stack overflow during agents/workers-types generation.

Fix: when render = old, return new' verbatim. The substitution target
is the value to insert; sub-references inside it are not additional
substitution opportunities. This is consistent with how every standard
text/term replace operation behaves.