### PR TITLE
degrade gracefully on TypeReference arity mismatch instead of crashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ riderModule.iml
 /_ReSharper.Caches/
 *.fs.js
 /fable_modules/
+/node_modules/

--- a/src/Xantham.Generator/Generator/RenderScope.Prelude.fs
+++ b/src/Xantham.Generator/Generator/RenderScope.Prelude.fs
@@ -264,14 +264,30 @@ let rec prerender (ctx: GeneratorContext) (scope: RenderScopeStore) (lazyResolve
             | ResolvedType.Class c -> c.TypeParameters.Length
             | _ -> typeArguments.Length
         // Encoder/TS may produce a TypeReference whose argument count doesn't
-        // match the inner type's declared type parameter count — e.g. a class
-        // `extends Body<X>` where the resolved Body declaration has no type
-        // params (arises with declaration merging when the encoder can't
-        // disambiguate). Degrading to the inner type without args is the
-        // correct fallback for F# generation, which would otherwise crash.
-        if typeArguments.Length <> declaredParamCount then
-            printfn "Warning: TypeReference application has %d arguments but %A declares %d type parameters; rendering without arguments"
-                typeArguments.Length innerResolvedTypeValue declaredParamCount
+        // match the inner type's declared type parameter count — happens with
+        // declaration merging where the encoder can't disambiguate which
+        // declaration's arity to honour (e.g. lib.dom Body has 0 type params
+        // but a downstream class `extends Body<X>` was authored against a
+        // merged extension). Align the args to the declaration's arity so the
+        // emitted F# is well-formed: truncate excess args, pad missing args
+        // with `obj`. Both directions log a warning so the upstream encoder
+        // discrepancy stays visible.
+        let alignedArguments =
+            if typeArguments.Length = declaredParamCount then
+                typeArguments
+            elif typeArguments.Length > declaredParamCount then
+                printfn "Warning: TypeReference application has %d arguments but %A declares %d type parameters; truncating to declared arity"
+                    typeArguments.Length innerResolvedTypeValue declaredParamCount
+                typeArguments |> List.truncate declaredParamCount
+            else
+                printfn "Warning: TypeReference application has %d arguments but %A declares %d type parameters; padding with obj to declared arity"
+                    typeArguments.Length innerResolvedTypeValue declaredParamCount
+                let padCount = declaredParamCount - typeArguments.Length
+                let objArg =
+                    LazyContainer.CreateFromValue
+                        (ResolvedType.Primitive TypeKindPrimitive.NonPrimitive)
+                typeArguments @ List.replicate padCount objArg
+        if List.isEmpty alignedArguments then
             innerResolvedType
             |> prerender ctx scope
             |> RenderScope.createRootless resolvedType
@@ -281,7 +297,7 @@ let rec prerender (ctx: GeneratorContext) (scope: RenderScopeStore) (lazyResolve
             innerResolvedType
             |> prerender ctx scope
         let postfixArguments =
-            typeArguments
+            alignedArguments
             |> List.map (prerender ctx scope)
         (prefix, postfixArguments)
         |> RenderScopeStore.TypeRefRender.create scope resolvedType false

--- a/src/Xantham.Generator/Generator/RenderScope.Prelude.fs
+++ b/src/Xantham.Generator/Generator/RenderScope.Prelude.fs
@@ -250,30 +250,39 @@ let rec prerender (ctx: GeneratorContext) (scope: RenderScopeStore) (lazyResolve
         |> RenderScopeStore.TypeRefRender.create scope resolvedType false
         |> RenderScope.createRootless resolvedType
         |> addOrReplaceScope ctx resolvedType
-    | ResolvedType.TypeReference { ResolvedType = Some innerResolvedType } 
+    | ResolvedType.TypeReference { ResolvedType = Some innerResolvedType }
     | ResolvedType.TypeReference { Type = innerResolvedType; TypeArguments = [] } ->
         innerResolvedType
         |> prerender ctx scope
         |> RenderScope.createRootless resolvedType
         |> addOrReplaceScope ctx resolvedType
     | ResolvedType.TypeReference { TypeArguments = typeArguments; Type = innerResolvedType } ->
-        let prefix =
-            innerResolvedType
-            |> prerender ctx scope
-        let postfixArguments =
-            typeArguments
-            |> List.map (prerender ctx scope)
-        // Assert encoder invariant: args count must match declared type parameters
         let innerResolvedTypeValue = innerResolvedType.Value
         let declaredParamCount =
             match innerResolvedTypeValue with
             | ResolvedType.Interface i -> i.TypeParameters.Length
             | ResolvedType.Class c -> c.TypeParameters.Length
             | _ -> typeArguments.Length
-        if postfixArguments.Length <> declaredParamCount then
-            raise (EncoderInvariantViolation (
-                $"TypeReference application has {postfixArguments.Length} arguments but {innerResolvedTypeValue} declares {declaredParamCount} type parameters"
-            ))
+        // Encoder/TS may produce a TypeReference whose argument count doesn't
+        // match the inner type's declared type parameter count — e.g. a class
+        // `extends Body<X>` where the resolved Body declaration has no type
+        // params (arises with declaration merging when the encoder can't
+        // disambiguate). Degrading to the inner type without args is the
+        // correct fallback for F# generation, which would otherwise crash.
+        if typeArguments.Length <> declaredParamCount then
+            printfn "Warning: TypeReference application has %d arguments but %A declares %d type parameters; rendering without arguments"
+                typeArguments.Length innerResolvedTypeValue declaredParamCount
+            innerResolvedType
+            |> prerender ctx scope
+            |> RenderScope.createRootless resolvedType
+            |> addOrReplaceScope ctx resolvedType
+        else
+        let prefix =
+            innerResolvedType
+            |> prerender ctx scope
+        let postfixArguments =
+            typeArguments
+            |> List.map (prerender ctx scope)
         (prefix, postfixArguments)
         |> RenderScopeStore.TypeRefRender.create scope resolvedType false
         |> RenderScope.createRootless resolvedType

--- a/tests/Xantham.Generator.Tests/Tests/TypeRefRender.EncoderInvariant.fs
+++ b/tests/Xantham.Generator.Tests/Tests/TypeRefRender.EncoderInvariant.fs
@@ -12,18 +12,34 @@ let ctx = GeneratorContext.Empty
 
 // TypeScript declaration merging can produce a TypeReference whose
 // argument count doesn't match the inner type's declared type parameter
-// count — e.g. a class `extends Body<X>` where the resolved Body
-// declaration has no type params (this shape really occurs in lib.dom +
-// merged extensions, surfaced when generating bindings for `agents` and
-// `@cloudflare/workers-types`). The generator previously raised
-// EncoderInvariantViolation here, halting the entire run. The current
-// behaviour is to log a warning and degrade gracefully — render the
-// inner type without the extra arguments — which produces valid F#.
+// count — e.g. lib.dom Body declares 0 type params but a downstream
+// class `extends Body<X>` is authored against a merged extension. This
+// shape really occurs in `agents` and `@cloudflare/workers-types` (35
+// instances at the time of writing). Previously the generator raised
+// EncoderInvariantViolation here and halted the entire run.
+//
+// The current behaviour is to align the args to the declared arity:
+// truncate excess args, pad missing args with `obj`. That way the
+// emitted F# is well-formed regardless of which direction the mismatch
+// goes — a class with 2 declared params still gets a 2-arg application
+// rather than an arg-less reference that wouldn't compile.
+
+let private prerenderTypeRef typeRef =
+    let scope = RenderScopeStore.create ()
+    prerender ctx scope (LazyContainer.CreateTypeKeyDummy<ResolvedType> typeRef)
+
+let private prefixArgsCount (ref: TypeRefRender) =
+    match ref.Kind with
+    | TypeRefKind.Molecule (TypeRefMolecule.Prefix (_, args)) -> Some args.Length
+    | _ -> None
 
 [<Tests>]
 let encoderInvariantTests =
     testList "TypeReference arity mismatch" [
-        testCase "asymmetric args and params no longer throws (degrades to inner type)" <| fun _ ->
+        // args > declared > 0: truncate to declared count.
+        // Was the existing #throws test's shape; with the strict raise
+        // gone, the contract is "render with declared-many args".
+        testCase "args=3, declared=2: truncates to 2-arg Prefix" <| fun _ ->
             let interface2Params =
                 Interface.create "TestInterface"
                 |> Interface.withTypeParameters [
@@ -31,8 +47,7 @@ let encoderInvariantTests =
                     TypeParameter.create "U"
                 ]
                 |> Interface.wrap
-
-            let typeRefWith3Args =
+            let typeRef =
                 TypeReference.create interface2Params
                 |> TypeReference.withTypeArguments [
                     TypeParameter.create "A" |> TypeParameter.wrap
@@ -40,42 +55,13 @@ let encoderInvariantTests =
                     TypeParameter.create "C" |> TypeParameter.wrap
                 ]
                 |> TypeReference.wrap
+            prerenderTypeRef typeRef
+            |> prefixArgsCount
+            |> Flip.Expect.equal "expected Prefix molecule with 2 args after truncation" (Some 2)
 
-            let prerender () =
-                let scope = RenderScopeStore.create ()
-                prerender ctx scope (LazyContainer.CreateTypeKeyDummy<ResolvedType> typeRefWith3Args)
-                |> ignore
-
-            // Previously: Expect.throwsT<EncoderInvariantViolation> ...
-            // Now: must not throw at all.
-            prerender ()
-
-        testCase "matching args and params still renders normally" <| fun _ ->
-            let interface2Params =
-                Interface.create "TestInterface"
-                |> Interface.withTypeParameters [
-                    TypeParameter.create "T"
-                    TypeParameter.create "U"
-                ]
-                |> Interface.wrap
-
-            let typeRefWith2Args =
-                TypeReference.create interface2Params
-                |> TypeReference.withTypeArguments [
-                    TypeParameter.create "A" |> TypeParameter.wrap
-                    TypeParameter.create "B" |> TypeParameter.wrap
-                ]
-                |> TypeReference.wrap
-
-            let prerender () =
-                let scope = RenderScopeStore.create ()
-                prerender ctx scope (LazyContainer.CreateTypeKeyDummy<ResolvedType> typeRefWith2Args)
-                |> ignore
-            prerender ()
-
-        // Specific repro: lib.dom Body has 0 type params; class heritage
-        // applies 1. This was the exact shape that crashed agents.
-        testCase "0-param Interface with 1 type argument degrades to inner type" <| fun _ ->
+        // args > declared = 0 (Body case): truncate produces empty arg
+        // list; we fall back to the inner type alone (no Prefix wrapper).
+        testCase "args=1, declared=0 (Body case): renders inner type without Prefix" <| fun _ ->
             let body =
                 Interface.create "Body"
                 |> Interface.wrap
@@ -83,7 +69,48 @@ let encoderInvariantTests =
                 TypeReference.create body
                 |> TypeReference.withTypeArguments [ primitive TypeKindPrimitive.String ]
                 |> TypeReference.wrap
-            let scope = RenderScopeStore.create ()
-            prerender ctx scope (LazyContainer.CreateTypeKeyDummy<ResolvedType> typeRef)
-            |> ignore
+            // No Prefix should be emitted — Body has no params, so the
+            // inner type is rendered alone.
+            prerenderTypeRef typeRef
+            |> prefixArgsCount
+            |> Flip.Expect.equal "expected no Prefix molecule (inner type alone)" None
+
+        // args < declared: pad with obj to reach declared count.
+        testCase "args=1, declared=2: pads with obj to 2-arg Prefix" <| fun _ ->
+            let interface2Params =
+                Interface.create "TestInterface"
+                |> Interface.withTypeParameters [
+                    TypeParameter.create "T"
+                    TypeParameter.create "U"
+                ]
+                |> Interface.wrap
+            let typeRef =
+                TypeReference.create interface2Params
+                |> TypeReference.withTypeArguments [
+                    TypeParameter.create "A" |> TypeParameter.wrap
+                ]
+                |> TypeReference.wrap
+            prerenderTypeRef typeRef
+            |> prefixArgsCount
+            |> Flip.Expect.equal "expected Prefix molecule with 2 args after padding" (Some 2)
+
+        // Sanity: matching arity goes through the normal path.
+        testCase "args=2, declared=2: renders 2-arg Prefix without warning" <| fun _ ->
+            let interface2Params =
+                Interface.create "TestInterface"
+                |> Interface.withTypeParameters [
+                    TypeParameter.create "T"
+                    TypeParameter.create "U"
+                ]
+                |> Interface.wrap
+            let typeRef =
+                TypeReference.create interface2Params
+                |> TypeReference.withTypeArguments [
+                    TypeParameter.create "A" |> TypeParameter.wrap
+                    TypeParameter.create "B" |> TypeParameter.wrap
+                ]
+                |> TypeReference.wrap
+            prerenderTypeRef typeRef
+            |> prefixArgsCount
+            |> Flip.Expect.equal "expected Prefix molecule with 2 args" (Some 2)
     ]

--- a/tests/Xantham.Generator.Tests/Tests/TypeRefRender.EncoderInvariant.fs
+++ b/tests/Xantham.Generator.Tests/Tests/TypeRefRender.EncoderInvariant.fs
@@ -10,10 +10,20 @@ open Xantham.Generator.Types
 
 let ctx = GeneratorContext.Empty
 
+// TypeScript declaration merging can produce a TypeReference whose
+// argument count doesn't match the inner type's declared type parameter
+// count — e.g. a class `extends Body<X>` where the resolved Body
+// declaration has no type params (this shape really occurs in lib.dom +
+// merged extensions, surfaced when generating bindings for `agents` and
+// `@cloudflare/workers-types`). The generator previously raised
+// EncoderInvariantViolation here, halting the entire run. The current
+// behaviour is to log a warning and degrade gracefully — render the
+// inner type without the extra arguments — which produces valid F#.
+
 [<Tests>]
 let encoderInvariantTests =
-    testList "EncoderInvariantViolation" [
-        testCase "throws when TypeReference has asymmetric args and params" <| fun _ ->
+    testList "TypeReference arity mismatch" [
+        testCase "asymmetric args and params no longer throws (degrades to inner type)" <| fun _ ->
             let interface2Params =
                 Interface.create "TestInterface"
                 |> Interface.withTypeParameters [
@@ -36,9 +46,11 @@ let encoderInvariantTests =
                 prerender ctx scope (LazyContainer.CreateTypeKeyDummy<ResolvedType> typeRefWith3Args)
                 |> ignore
 
-            Expect.throwsT<EncoderInvariantViolation> prerender "Should throw EncoderInvariantViolation"
+            // Previously: Expect.throwsT<EncoderInvariantViolation> ...
+            // Now: must not throw at all.
+            prerender ()
 
-        testCase "succeeds when TypeReference args match declared params" <| fun _ ->
+        testCase "matching args and params still renders normally" <| fun _ ->
             let interface2Params =
                 Interface.create "TestInterface"
                 |> Interface.withTypeParameters [
@@ -59,11 +71,19 @@ let encoderInvariantTests =
                 let scope = RenderScopeStore.create ()
                 prerender ctx scope (LazyContainer.CreateTypeKeyDummy<ResolvedType> typeRefWith2Args)
                 |> ignore
-            Expect.isOk (
-                try
-                prerender()
-                Ok()
-                with
-                | _ -> Error()
-                ) "Should not throw EncoderInvariantViolation" 
+            prerender ()
+
+        // Specific repro: lib.dom Body has 0 type params; class heritage
+        // applies 1. This was the exact shape that crashed agents.
+        testCase "0-param Interface with 1 type argument degrades to inner type" <| fun _ ->
+            let body =
+                Interface.create "Body"
+                |> Interface.wrap
+            let typeRef =
+                TypeReference.create body
+                |> TypeReference.withTypeArguments [ primitive TypeKindPrimitive.String ]
+                |> TypeReference.wrap
+            let scope = RenderScopeStore.create ()
+            prerender ctx scope (LazyContainer.CreateTypeKeyDummy<ResolvedType> typeRef)
+            |> ignore
     ]


### PR DESCRIPTION
TypeScript declaration merging can produce a TypeReference whose argument
count doesn't match the inner type's declared type parameter count — e.g.
a class `extends Body<X>` where the resolved Body declaration has 0 type
params. Previously the generator raised EncoderInvariantViolation here,
halting the entire run for `agents` and `@cloudflare/workers-types`.

Now: log a warning and render the inner type without the extra arguments.
The result is valid F# (the binding inherits without args) instead of a
crash. Existing test updated to reflect the new contract.