### PR TITLE
chore(ai): wire up fslangmcp for semantic F# navigation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__fslangmcp"
+    ]
+  },
+  "enabledMcpjsonServers": ["fslangmcp"]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "fslangmcp": {
+      "type": "stdio",
+      "command": "fslangmcp",
+      "args": ["--project", "Xantham.slnx"],
+      "env": {}
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,44 @@ the table below first. `.archive/scratch/tmp/tsgo-native` is a checkout of the d
   vendored `ast.json` and `enums/`.
 - `dotnet fsi tools/generate-wire.fsx generate proto` — emit the `Proto*.generated.fs` files.
 
+## F# semantics — use `fslangmcp`, not grep
+
+The repo ships an `fslangmcp` MCP server (`.mcp.json`, FsLangMCP 0.16.0 over FSAC +
+FSharp.Compiler.Service). It loads `Xantham.slnx`, so it sees exactly the two projects the
+solution references — `.archive/` is invisible to it, which is the behaviour this repo wants.
+Requires the `fslangmcp`, `fsautocomplete` and `fantomas` global tools; `fslangmcp
+--bootstrap-tools` installs the pinned set.
+
+**Answer semantic questions about F# code with it. Reach for grep only for prose, JSON, `.mts`
+tooling and other non-F# files.** Over 26k lines of `*.generated.fs` sit in `src/`, so textual
+search over-matches badly: short binding names like `decode` or `is` recur in thousands of
+generated members, and `find` resolves the real symbol instead.
+
+- `find` — definitions and cross-project use sites, each tagged `definition`/`reference` with a
+  coverage block. **Run `check` first.** When the workspace does not type-check, `find` returns
+  `outcome="not_found"` *with* `coverage.complete: true` — a confidently wrong negative, not the
+  indeterminate answer the coverage contract implies. Verified: `find "VirtualFileSystem"` matches
+  on a clean tree and reports not_found on the same tree with unrelated compile errors. Never
+  conclude "no usages" from a `find` taken while `check` says `errors`.
+- `check` — fresh whole-workspace type-check verdict (`clean`/`errors`) with structured
+  diagnostics, no build artifacts. Roughly 8s. An incremental `dotnet build Xantham.slnx` is
+  about as fast, so prefer `check` for the structured diagnostics, not for speed.
+- `fcs_refactor_impact` — run this *before* changing any public signature. Returns blast radius,
+  whether the symbol is public API (i.e. a breaking change), covering tests, and a verify list.
+- `fcs_tests_for_symbol` — which tests cover a symbol, resolved to the enclosing Expecto
+  `testCase` name. Only finds direct call sites; much of the suite exercises the library
+  indirectly through the wire, so an empty result means "not called by name", not "untested".
+- `fcs_public_api` — stable-ordered public surface, for diffing API before/after a change.
+- `fcs_nuget_types` / `fcs_nuget_members` / `fcs_referenced_symbols` — inspect referenced
+  assemblies without unpacking packages.
+
+Pass `projectPath` explicitly on `fcs_*` calls when several agents run at once; caches are keyed
+per resolved `.fsproj`. `fcs_dead_code` on the Wire project is dominated by generated-file
+internals — treat its output as candidates to filter, not a work list.
+
+Serena's symbol tools (`find_symbol`, `find_referencing_symbols`) do **not** work on this repo —
+its language server fails on `.archive/` and on `Library.fs`. Use `fslangmcp` instead.
+
 ## Architecture Notes
 
 - Nothing is hand-transcribed that can be generated. Facts that must be transcribed are


### PR DESCRIPTION
Registers [FsLangMCP](https://github.com/Neftedollar/FsLangMCP) 0.16.0 (FSAC + FSharp.Compiler.Service) as a project MCP server, so agents resolve F# symbols through the compiler instead of grepping 26k+ lines of generated sources.

## Why

Evaluated by driving the server over stdio against this repo, not from its README:

- **Serena's F# tools are broken here.** `find_symbol` raises on `.archive/` and on `src/.../Library.fs`.
- **Rider MCP has no find-usages tool.** `search_symbol("TsGoCallback")` returns the definition line only.
- **Grep over-matches badly.** `decode` and `is` recur across thousands of generated members.

fslangmcp resolved `TsGoCallback` to 6 exact sites with cross-project coverage. `fcs_refactor_impact` (blast radius + public-API breaking-change verdict, ~3s) and `fcs_tests_for_symbol` (resolves to the enclosing Expecto `testCase`) have no equivalent in the existing toolset.

## Contents

- `.mcp.json` — stdio server preloading `Xantham.slnx` by **relative** path, verified working from a worktree. Loading via the solution keeps `.archive/` out of scope.
- `.claude/settings.json` — enables the server and allows its tools. Every tool is read-only; previews return edits without writing to disk.
- `AGENTS.md` — tool-selection guidance plus the caveats found during evaluation.

## Caveats documented, not glossed

- **`find` returns confident false negatives.** On a tree with unrelated compile errors it reports `outcome="not_found"` with `coverage.complete: true` — contradicting the project's stated coverage contract. Verified: the same query matches on a clean tree. AGENTS.md tells agents to run `check` first.
- `check` is ~8.6s vs ~6.9s for an incremental `dotnet build` — use it for structured diagnostics, not speed.
- FSAC itself cannot parse `.slnx`; fslangmcp recovers and loads both projects.

Requires the `fslangmcp`, `fsautocomplete` and `fantomas` global tools (`fslangmcp --bootstrap-tools`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)